### PR TITLE
feat: use pubkey hash as client account id and remove lzNonce for delegation precompile

### DIFF
--- a/src/core/ImuachainGateway.sol
+++ b/src/core/ImuachainGateway.sol
@@ -446,10 +446,9 @@ contract ImuachainGateway is
     /// @dev Can only be called from this contract via low-level call.
     /// @dev Returns empty response because the client chain should not expect a response.
     /// @param srcChainId The source chain id.
-    /// @param lzNonce The layer zero nonce.
     /// @param act The action type.
     /// @param payload The request payload.
-    function handleDelegation(uint32 srcChainId, uint64 lzNonce, Action act, bytes calldata payload)
+    function handleDelegation(uint32 srcChainId, uint64, Action act, bytes calldata payload)
         public
         onlyCalledFromThis
         returns (bytes memory response)
@@ -463,9 +462,9 @@ contract ImuachainGateway is
         bool isDelegate = act == Action.REQUEST_DELEGATE_TO;
         bool accepted;
         if (isDelegate) {
-            accepted = DELEGATION_CONTRACT.delegate(srcChainId, lzNonce, token, staker, operator, amount);
+            accepted = DELEGATION_CONTRACT.delegate(srcChainId, token, staker, operator, amount);
         } else {
-            accepted = DELEGATION_CONTRACT.undelegate(srcChainId, lzNonce, token, staker, operator, amount);
+            accepted = DELEGATION_CONTRACT.undelegate(srcChainId, token, staker, operator, amount);
         }
         emit DelegationRequest(isDelegate, accepted, bytes32(token), bytes32(staker), string(operator), amount);
     }
@@ -494,7 +493,7 @@ contract ImuachainGateway is
         }
         emit LSTTransfer(true, success, bytes32(token), bytes32(depositor), amount);
 
-        bool accepted = DELEGATION_CONTRACT.delegate(srcChainId, lzNonce, token, depositor, operator, amount);
+        bool accepted = DELEGATION_CONTRACT.delegate(srcChainId, token, depositor, operator, amount);
         emit DelegationRequest(true, accepted, bytes32(token), bytes32(depositor), string(operator), amount);
     }
 

--- a/src/interfaces/precompiles/IDelegation.sol
+++ b/src/interfaces/precompiles/IDelegation.sol
@@ -20,14 +20,12 @@ interface IDelegation {
     /// @param clientChainID is the layerZero chainID if it is supported.
     //  It might be allocated by Imuachain when the client chain isn't supported
     //  by layerZero
-    /// @param lzNonce The cross chain tx layerZero nonce
     /// @param assetsAddress The client chain asset Address
     /// @param stakerAddress The staker address
     /// @param operatorAddr  The operator address that wants to be delegated to
     /// @param opAmount The delegation amount
     function delegate(
         uint32 clientChainID,
-        uint64 lzNonce,
         bytes calldata assetsAddress,
         bytes calldata stakerAddress,
         bytes calldata operatorAddr,
@@ -41,14 +39,12 @@ interface IDelegation {
     /// @param clientChainID is the layerZero chainID if it is supported.
     //  It might be allocated by Imuachain when the client chain isn't supported
     //  by layerZero
-    /// @param lzNonce The cross chain tx layerZero nonce
     /// @param assetsAddress The client chain asset Address
     /// @param stakerAddress The staker address
     /// @param operatorAddr  The operator address that wants to unDelegate from
     /// @param opAmount The Undelegation amount
     function undelegate(
         uint32 clientChainID,
-        uint64 lzNonce,
         bytes calldata assetsAddress,
         bytes calldata stakerAddress,
         bytes calldata operatorAddr,

--- a/test/foundry/Delegation.t.sol
+++ b/test/foundry/Delegation.t.sol
@@ -32,20 +32,10 @@ contract DelegateTest is ImuachainDeployer {
         uint256 amount
     );
     event DelegateRequestProcessed(
-        uint32 clientChainLzId,
-        uint64 lzNonce,
-        bytes assetsAddress,
-        bytes stakerAddress,
-        string operatorAddr,
-        uint256 opAmount
+        uint32 clientChainLzId, bytes assetsAddress, bytes stakerAddress, string operatorAddr, uint256 opAmount
     );
     event UndelegateRequestProcessed(
-        uint32 clientChainLzId,
-        uint64 lzNonce,
-        bytes assetsAddress,
-        bytes stakerAddress,
-        string operatorAddr,
-        uint256 opAmount
+        uint32 clientChainLzId, bytes assetsAddress, bytes stakerAddress, string operatorAddr, uint256 opAmount
     );
 
     function setUp() public override {
@@ -125,7 +115,6 @@ contract DelegateTest is ImuachainDeployer {
         vm.expectEmit(true, true, true, true, DELEGATION_PRECOMPILE_ADDRESS);
         emit DelegateRequestProcessed(
             clientChainId,
-            outboundNonces[clientChainId] - 1,
             abi.encodePacked(bytes32(bytes20(address(restakeToken)))),
             abi.encodePacked(bytes32(bytes20(delegator.addr))),
             operatorAddress,
@@ -210,7 +199,6 @@ contract DelegateTest is ImuachainDeployer {
         vm.expectEmit(true, true, true, true, DELEGATION_PRECOMPILE_ADDRESS);
         emit UndelegateRequestProcessed(
             clientChainId,
-            outboundNonces[clientChainId] - 1,
             abi.encodePacked(bytes32(bytes20(address(restakeToken)))),
             abi.encodePacked(bytes32(bytes20(delegator.addr))),
             operatorAddress,

--- a/test/foundry/DepositThenDelegateTo.t.sol
+++ b/test/foundry/DepositThenDelegateTo.t.sol
@@ -34,12 +34,7 @@ contract DepositThenDelegateToTest is ImuachainDeployer {
 
     // emitted by the mock delegation contract
     event DelegateRequestProcessed(
-        uint32 clientChainLzId,
-        uint64 lzNonce,
-        bytes assetsAddress,
-        bytes stakerAddress,
-        string operatorAddr,
-        uint256 opAmount
+        uint32 clientChainLzId, bytes assetsAddress, bytes stakerAddress, string operatorAddr, uint256 opAmount
     );
 
     function test_DepositThenDelegateTo() public {
@@ -166,7 +161,6 @@ contract DepositThenDelegateToTest is ImuachainDeployer {
         vm.expectEmit(DELEGATION_PRECOMPILE_ADDRESS);
         emit DelegateRequestProcessed(
             clientChainId,
-            outboundNonces[clientChainId] - 1,
             abi.encodePacked(bytes32(bytes20(address(restakeToken)))),
             abi.encodePacked(bytes32(bytes20(delegator))),
             operatorAddress,
@@ -220,7 +214,6 @@ contract DepositThenDelegateToTest is ImuachainDeployer {
         bytes memory delegateCalldata = abi.encodeWithSelector(
             IDelegation.delegate.selector,
             clientChainId,
-            outboundNonces[clientChainId] - 1,
             abi.encodePacked(bytes32(bytes20(address(restakeToken)))),
             abi.encodePacked(bytes32(bytes20(delegator))),
             "im13hasr43vvq8v44xpzh0l6yuym4kca98fhq3xla",

--- a/test/mocks/DelegationMock.sol
+++ b/test/mocks/DelegationMock.sol
@@ -11,25 +11,14 @@ contract DelegationMock is IDelegation {
     mapping(uint32 chainId => bool registered) isRegisteredChain;
 
     event DelegateRequestProcessed(
-        uint32 clientChainLzId,
-        uint64 lzNonce,
-        bytes assetsAddress,
-        bytes stakerAddress,
-        string operatorAddr,
-        uint256 opAmount
+        uint32 clientChainLzId, bytes assetsAddress, bytes stakerAddress, string operatorAddr, uint256 opAmount
     );
     event UndelegateRequestProcessed(
-        uint32 clientChainLzId,
-        uint64 lzNonce,
-        bytes assetsAddress,
-        bytes stakerAddress,
-        string operatorAddr,
-        uint256 opAmount
+        uint32 clientChainLzId, bytes assetsAddress, bytes stakerAddress, string operatorAddr, uint256 opAmount
     );
 
     function delegate(
         uint32 clientChainLzId,
-        uint64 lzNonce,
         bytes calldata assetsAddress,
         bytes calldata stakerAddress,
         bytes calldata operatorAddr,
@@ -42,16 +31,13 @@ contract DelegationMock is IDelegation {
             return false;
         }
         delegateToRecords[stakerAddress][operatorAddr][clientChainLzId][assetsAddress] += opAmount;
-        emit DelegateRequestProcessed(
-            clientChainLzId, lzNonce, assetsAddress, stakerAddress, string(operatorAddr), opAmount
-        );
+        emit DelegateRequestProcessed(clientChainLzId, assetsAddress, stakerAddress, string(operatorAddr), opAmount);
 
         return true;
     }
 
     function undelegate(
         uint32 clientChainLzId,
-        uint64 lzNonce,
         bytes calldata assetsAddress,
         bytes calldata stakerAddress,
         bytes calldata operatorAddr,
@@ -67,9 +53,7 @@ contract DelegationMock is IDelegation {
             return false;
         }
         delegateToRecords[stakerAddress][operatorAddr][clientChainLzId][assetsAddress] -= opAmount;
-        emit UndelegateRequestProcessed(
-            clientChainLzId, lzNonce, assetsAddress, stakerAddress, string(operatorAddr), opAmount
-        );
+        emit UndelegateRequestProcessed(clientChainLzId, assetsAddress, stakerAddress, string(operatorAddr), opAmount);
 
         return true;
     }

--- a/test/mocks/ImuachainGatewayMock.sol
+++ b/test/mocks/ImuachainGatewayMock.sol
@@ -473,9 +473,9 @@ contract ImuachainGatewayMock is
         bool isDelegate = act == Action.REQUEST_DELEGATE_TO;
         bool accepted;
         if (isDelegate) {
-            accepted = DELEGATION_CONTRACT.delegate(srcChainId, lzNonce, token, staker, operator, amount);
+            accepted = DELEGATION_CONTRACT.delegate(srcChainId, token, staker, operator, amount);
         } else {
-            accepted = DELEGATION_CONTRACT.undelegate(srcChainId, lzNonce, token, staker, operator, amount);
+            accepted = DELEGATION_CONTRACT.undelegate(srcChainId, token, staker, operator, amount);
         }
         emit DelegationRequest(isDelegate, accepted, bytes32(token), bytes32(staker), string(operator), amount);
     }
@@ -504,7 +504,7 @@ contract ImuachainGatewayMock is
         }
         emit LSTTransfer(true, success, bytes32(token), bytes32(depositor), amount);
 
-        bool accepted = DELEGATION_CONTRACT.delegate(srcChainId, lzNonce, token, depositor, operator, amount);
+        bool accepted = DELEGATION_CONTRACT.delegate(srcChainId, token, depositor, operator, amount);
         emit DelegationRequest(true, accepted, bytes32(token), bytes32(depositor), string(operator), amount);
     }
 


### PR DESCRIPTION
## Description

Though the bitcoin address has different formats like base58check, bech32 or others based on address versions, and address length would vary for different versions, the underlying bytes representation is always the same length - 20 bytes and is the hash of user's pubkey or hash of script. So given a bitcoin address, we could decode it to get its pubkey hash and version, that is to say we can safely use the pubkey hash as user's account id(different versions would only result in different address encoding). This PR is involved mainly with using pubkey hash as staker's client account id. And also it removes `lzNonce` from delegation precompile functions `delegateTo`, `undelegateFrom`, since `lzNonce` is no longer needed for delegate/undelegate.