### PR TITLE
feat: increase max effective balance after pectra

### DIFF
--- a/src/core/Bootstrap.sol
+++ b/src/core/Bootstrap.sol
@@ -733,7 +733,10 @@ contract Bootstrap is
         nonReentrant
         nativeRestakingEnabled
     {
-        if (msg.value != 32 ether) {
+        if (
+            msg.value < AFTER_PECTRA_MIN_ACTIVATION_BALANCE_ETH_PER_VALIDATOR
+                || msg.value > AFTER_PECTRA_MAX_EFFECTIVE_BALANCE_ETH_PER_VALIDATOR
+        ) {
             revert Errors.NativeRestakingControllerInvalidStakeValue();
         }
 

--- a/src/core/ImuaCapsule.sol
+++ b/src/core/ImuaCapsule.sol
@@ -138,8 +138,8 @@ contract ImuaCapsule is ReentrancyGuardUpgradeable, ImuaCapsuleStorage, IImuaCap
         validator.status = VALIDATOR_STATUS.REGISTERED;
         validator.validatorIndex = proof.validatorIndex;
         uint64 depositAmountGwei = validatorContainer.getEffectiveBalance();
-        if (depositAmountGwei > MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR) {
-            depositAmount = MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR * GWEI_TO_WEI;
+        if (depositAmountGwei > AFTER_PECTRA_MAX_EFFECTIVE_BALANCE_GWEI_PER_VALIDATOR) {
+            depositAmount = AFTER_PECTRA_MAX_EFFECTIVE_BALANCE_GWEI_PER_VALIDATOR * GWEI_TO_WEI;
         } else {
             depositAmount = depositAmountGwei * GWEI_TO_WEI;
         }

--- a/src/core/NativeRestakingController.sol
+++ b/src/core/NativeRestakingController.sol
@@ -43,7 +43,10 @@ abstract contract NativeRestakingController is
         nonReentrant
         nativeRestakingEnabled
     {
-        if (msg.value != 32 ether) {
+        if (
+            msg.value < AFTER_PECTRA_MIN_ACTIVATION_BALANCE_ETH_PER_VALIDATOR
+                || msg.value > AFTER_PECTRA_MAX_EFFECTIVE_BALANCE_ETH_PER_VALIDATOR
+        ) {
             revert Errors.NativeRestakingControllerInvalidStakeValue();
         }
 

--- a/src/storage/BootstrapStorage.sol
+++ b/src/storage/BootstrapStorage.sol
@@ -25,6 +25,36 @@ import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 contract BootstrapStorage is GatewayStorage {
 
     /* -------------------------------------------------------------------------- */
+    /*     constants and immutables(hardcoded into code so not part of state)     */
+    /* -------------------------------------------------------------------------- */
+
+    /// @notice The beacon for the ImuaCapsule contract, which stores the ImuaCapsule implementation.
+    IBeacon public immutable IMUA_CAPSULE_BEACON;
+
+    /// @notice The address of the beacon chain oracle.
+    address public immutable BEACON_ORACLE_ADDRESS;
+
+    /// @dev The (virtual) address for native staking token.
+    address internal constant VIRTUAL_NST_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+    /// @dev The address of the ETHPOS deposit contract.
+    IETHPOSDeposit internal immutable ETH_POS;
+
+    /// @notice Used to identify the specific chain this contract interacts with for cross-chain functionalities.
+    /// @dev Stores the Layer Zero chain ID of Imuachain.
+    uint32 public immutable IMUACHAIN_CHAIN_ID;
+
+    /// @notice This stores the Vault implementation contract address for proxy, and it is shared among all beacon
+    /// proxies.
+    IBeacon public immutable VAULT_BEACON;
+
+    /// @notice The minimum amount of ETH required to activate a validator after Pectra, in ETH.
+    uint256 public constant AFTER_PECTRA_MIN_ACTIVATION_BALANCE_ETH_PER_VALIDATOR = 32 ether;
+
+    /// @notice The maximum amount that a validator can stake to Ethereum after Pectra, in ETH.
+    uint256 public constant AFTER_PECTRA_MAX_EFFECTIVE_BALANCE_ETH_PER_VALIDATOR = 2048 ether;
+
+    /* -------------------------------------------------------------------------- */
     /*               state variables exclusively owned by Bootstrap               */
     /* -------------------------------------------------------------------------- */
 
@@ -132,26 +162,6 @@ contract BootstrapStorage is GatewayStorage {
     /// contract instance handling its operations.
     /// @dev Maps token addresses to their corresponding vault contracts.
     mapping(address token => IVault vault) public tokenToVault;
-
-    /// @notice The beacon for the ImuaCapsule contract, which stores the ImuaCapsule implementation.
-    IBeacon public immutable IMUA_CAPSULE_BEACON;
-
-    /// @notice The address of the beacon chain oracle.
-    address public immutable BEACON_ORACLE_ADDRESS;
-
-    /// @dev The (virtual) address for native staking token.
-    address internal constant VIRTUAL_NST_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
-
-    /// @dev The address of the ETHPOS deposit contract.
-    IETHPOSDeposit internal immutable ETH_POS;
-
-    /// @notice Used to identify the specific chain this contract interacts with for cross-chain functionalities.
-    /// @dev Stores the Layer Zero chain ID of Imuachain.
-    uint32 public immutable IMUACHAIN_CHAIN_ID;
-
-    /// @notice This stores the Vault implementation contract address for proxy, and it is shared among all beacon
-    /// proxies.
-    IBeacon public immutable VAULT_BEACON;
 
     /// @notice A standalone contract that is dedicated for providing the bytecode of beacon proxy contract.
     /// @dev We do not store bytecode of beacon proxy contract in this storage because that would cause the code size of

--- a/src/storage/ImuaCapsuleStorage.sol
+++ b/src/storage/ImuaCapsuleStorage.sol
@@ -56,8 +56,8 @@ contract ImuaCapsuleStorage {
     /// @notice Conversion factor from gwei to wei.
     uint256 public constant GWEI_TO_WEI = 1e9;
 
-    /// @notice The maximum amount of balance that a validator can restake, in gwei.
-    uint64 public constant MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR = 32e9;
+    /// @notice The maximum amount of effective balance that a validator can restake, in gwei.
+    uint64 public constant AFTER_PECTRA_MAX_EFFECTIVE_BALANCE_GWEI_PER_VALIDATOR = 2048e9;
 
     /// @notice The minimum interval between successful NST claims.
     uint256 public constant MIN_CLAIM_INTERVAL = 10 minutes;

--- a/test/foundry/BootstrapDepositNST.t.sol
+++ b/test/foundry/BootstrapDepositNST.t.sol
@@ -197,8 +197,8 @@ contract BootstrapDepositNSTTest is Test {
 
         // Calculate expected deposit value
         uint256 expectedDepositValue = uint256(_getEffectiveBalance(validatorContainer)) * GWEI_TO_WEI;
-        if (expectedDepositValue > 32 ether) {
-            expectedDepositValue = 32 ether;
+        if (expectedDepositValue > 2048 ether) {
+            expectedDepositValue = 2048 ether;
         }
 
         // Record initial states

--- a/test/foundry/DepositWithdrawPrincipal.t.sol
+++ b/test/foundry/DepositWithdrawPrincipal.t.sol
@@ -34,7 +34,7 @@ contract DepositWithdrawPrincipalTest is ImuachainDeployer {
     event PrincipalWithdrawn(address indexed src, address indexed dst, uint256 amount);
 
     uint256 constant DEFAULT_ENDPOINT_CALL_GAS_LIMIT = 200_000;
-    uint64 public constant MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR = 32e9;
+    uint64 public constant MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR = 2048e9;
 
     function test_LSTDepositWithdrawByLayerZero() public {
         Player memory depositor = players[0];
@@ -246,9 +246,9 @@ contract DepositWithdrawPrincipalTest is ImuachainDeployer {
         uint256 lastlyUpdatedPrincipalBalance;
 
         uint256 depositAmount = uint256(_getEffectiveBalance(validatorContainer)) * GWEI_TO_WEI;
-        // Cap to 32 ether
-        if (depositAmount >= 32 ether) {
-            depositAmount = 32 ether;
+        // Cap to 2048 ether
+        if (depositAmount >= 2048 ether) {
+            depositAmount = 2048 ether;
         }
 
         // transfer some ETH to depositor for staking and paying for gas fee
@@ -303,9 +303,9 @@ contract DepositWithdrawPrincipalTest is ImuachainDeployer {
 
         /// client chain layerzero endpoint should emit the message packet including deposit payload.
         uint256 depositAmount = uint256(_getEffectiveBalance(validatorContainer)) * GWEI_TO_WEI;
-        // Cap to 32 ether
-        if (depositAmount >= 32 ether) {
-            depositAmount = 32 ether;
+        // Cap to 2048 ether
+        if (depositAmount >= 2048 ether) {
+            depositAmount = 2048 ether;
         }
 
         bytes memory depositRequestPayload = abi.encodePacked(


### PR DESCRIPTION
## Description

After Ethereum Pectra upgrade, we are mostly influenced by EIP7251(https://eips.ethereum.org/EIPS/eip-7251), which increases the max effective balance per validator from 32 ether to 2048 ether, and maintains the minimum activation balance for active validator as 32 ether. This PR would simply:

1. update the original `MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR` inside `ImuaCapsuleStorage.sol`
2. add `AFTER_PECTRA_MIN_ACTIVATION_BALANCE_ETH_PER_VALIDATOR` and `AFTER_PECTRA_MAX_EFFECTIVE_BALANCE_ETH_PER_VALIDATOR` to `BootstrapStorage.sol`, so that we could check against the bounds when users call `stake` to stake to beacon chain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Increased the maximum allowable ETH stake and deposit limits for validators, enabling higher stake amounts up to 2048 ETH.
- **Bug Fixes**
  - Updated validation logic to accept a range of ETH stake amounts instead of requiring exactly 32 ETH.
- **Refactor**
  - Improved organization of contract constants and immutables for clarity.
  - Renamed and updated constants to reflect new staking thresholds.
- **Tests**
  - Adjusted test scenarios and deposit caps to match the new maximum stake and deposit limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->