### PR TITLE
chore: clientChain -> sepolia in deployedContracts.json

### DIFF
--- a/.github/workflows/forge-ci.yml
+++ b/.github/workflows/forge-ci.yml
@@ -151,11 +151,11 @@ jobs:
         run: |
           data=$(cat script/deployments/deployedContracts.json)
 
-          bootstrap=$(echo "$data" | jq -r '.clientChain.bootstrapLogic // empty')
-          clientGateway=$(echo "$data" | jq -r '.clientChain.clientGatewayLogic // empty')
-          vault=$(echo "$data" | jq -r '.clientChain.vaultImplementation // empty')
-          rewardVault=$(echo "$data" | jq -r '.clientChain.rewardVaultImplementation // empty')
-          capsule=$(echo "$data" | jq -r '.clientChain.capsuleImplementation // empty')
+          bootstrap=$(echo "$data" | jq -r '.sepolia.bootstrapLogic // empty')
+          clientGateway=$(echo "$data" | jq -r '.sepolia.clientGatewayLogic // empty')
+          vault=$(echo "$data" | jq -r '.sepolia.vaultImplementation // empty')
+          rewardVault=$(echo "$data" | jq -r '.sepolia.rewardVaultImplementation // empty')
+          capsule=$(echo "$data" | jq -r '.sepolia.capsuleImplementation // empty')
 
           validate_address() {
             local address=$1

--- a/script/10_DeployImuachainGatewayOnly.s.sol
+++ b/script/10_DeployImuachainGatewayOnly.s.sol
@@ -23,8 +23,6 @@ contract DeployImuachainGatewayOnly is BaseScript {
         string memory prerequisites = vm.readFile("script/deployments/prerequisiteContracts.json");
         imuachainLzEndpoint = ILayerZeroEndpointV2(stdJson.readAddress(prerequisites, ".imuachain.lzEndpoint"));
         require(address(imuachainLzEndpoint) != address(0), "imuachain l0 endpoint should not be empty");
-        // fork
-        imuachain = vm.createSelectFork(imuachainRPCURL);
         salt = keccak256(abi.encodePacked("imuachaintestnet_233-8"));
     }
 

--- a/script/12_RedeployClientChainGateway.s.sol
+++ b/script/12_RedeployClientChainGateway.s.sol
@@ -32,26 +32,37 @@ contract RedeployClientChainGateway is BaseScript {
         super.setUp();
         // load contracts
         string memory prerequisiteContracts = vm.readFile("script/deployments/deployedBootstrapOnly.json");
-        clientChainLzEndpoint =
-            ILayerZeroEndpointV2(stdJson.readAddress(prerequisiteContracts, ".clientChain.lzEndpoint"));
+        clientChainLzEndpoint = ILayerZeroEndpointV2(
+            stdJson.readAddress(prerequisiteContracts, string.concat(".", clientChainName, ".lzEndpoint"))
+        );
         require(address(clientChainLzEndpoint) != address(0), "client chain l0 endpoint should not be empty");
-        beaconOracle = EigenLayerBeaconOracle(stdJson.readAddress(prerequisiteContracts, ".clientChain.beaconOracle"));
+        beaconOracle = EigenLayerBeaconOracle(
+            stdJson.readAddress(prerequisiteContracts, string.concat(".", clientChainName, ".beaconOracle"))
+        );
         require(address(beaconOracle) != address(0), "beacon oracle should not be empty");
-        vaultBeacon = UpgradeableBeacon(stdJson.readAddress(prerequisiteContracts, ".clientChain.vaultBeacon"));
+        vaultBeacon = UpgradeableBeacon(
+            stdJson.readAddress(prerequisiteContracts, string.concat(".", clientChainName, ".vaultBeacon"))
+        );
         require(address(vaultBeacon) != address(0), "vault beacon should not be empty");
-        rewardVaultBeacon =
-            UpgradeableBeacon(stdJson.readAddress(prerequisiteContracts, ".clientChain.rewardVaultBeacon"));
+        rewardVaultBeacon = UpgradeableBeacon(
+            stdJson.readAddress(prerequisiteContracts, string.concat(".", clientChainName, ".rewardVaultBeacon"))
+        );
         require(address(rewardVaultBeacon) != address(0), "reward vault beacon should not be empty");
-        capsuleBeacon = UpgradeableBeacon(stdJson.readAddress(prerequisiteContracts, ".clientChain.capsuleBeacon"));
+        capsuleBeacon = UpgradeableBeacon(
+            stdJson.readAddress(prerequisiteContracts, string.concat(".", clientChainName, ".capsuleBeacon"))
+        );
         require(address(capsuleBeacon) != address(0), "capsule beacon should not be empty");
-        beaconProxyBytecode =
-            BeaconProxyBytecode(stdJson.readAddress(prerequisiteContracts, ".clientChain.beaconProxyBytecode"));
+        beaconProxyBytecode = BeaconProxyBytecode(
+            stdJson.readAddress(prerequisiteContracts, string.concat(".", clientChainName, ".beaconProxyBytecode"))
+        );
         require(address(beaconProxyBytecode) != address(0), "beacon proxy bytecode should not be empty");
-        bootstrap = Bootstrap(stdJson.readAddress(prerequisiteContracts, ".clientChain.bootstrap"));
+        bootstrap =
+            Bootstrap(stdJson.readAddress(prerequisiteContracts, string.concat(".", clientChainName, ".bootstrap")));
         require(address(bootstrap) != address(0), "bootstrap should not be empty");
-        clientChainProxyAdmin = CustomProxyAdmin(stdJson.readAddress(prerequisiteContracts, ".clientChain.proxyAdmin"));
+        clientChainProxyAdmin = CustomProxyAdmin(
+            stdJson.readAddress(prerequisiteContracts, string.concat(".", clientChainName, ".proxyAdmin"))
+        );
         require(address(clientChainProxyAdmin) != address(0), "client chain proxy admin should not be empty");
-        clientChain = vm.createSelectFork(clientChainRPCURL);
     }
 
     function run() public {
@@ -60,7 +71,7 @@ contract RedeployClientChainGateway is BaseScript {
 
         // Create ImmutableConfig struct
         BootstrapStorage.ImmutableConfig memory config = BootstrapStorage.ImmutableConfig({
-            imuachainChainId: imuachainChainId,
+            imuachainChainId: imuachainEndpointId,
             beaconOracleAddress: address(beaconOracle),
             vaultBeacon: address(vaultBeacon),
             imuaCapsuleBeacon: address(capsuleBeacon),
@@ -82,7 +93,7 @@ contract RedeployClientChainGateway is BaseScript {
             vm.serializeAddress(clientChainContracts, "clientGatewayLogic", address(clientGatewayLogic));
 
         string memory deployedContracts = "deployedContracts";
-        string memory finalJson = vm.serializeString(deployedContracts, "clientChain", clientChainContractsOutput);
+        string memory finalJson = vm.serializeString(deployedContracts, clientChainName, clientChainContractsOutput);
 
         vm.writeJson(finalJson, "script/deployments/redeployClientChainGateway.json");
     }

--- a/script/13_DepositValidator.s.sol
+++ b/script/13_DepositValidator.s.sol
@@ -38,11 +38,14 @@ contract DepositScript is BaseScript {
         string memory validatorInfo = vm.readFile("script/data/validatorProof_staker1_testnetV6.json");
         string memory deployedContracts = vm.readFile("script/deployments/deployedContracts.json");
 
-        clientGateway =
-            IClientChainGateway(payable(stdJson.readAddress(deployedContracts, ".clientChain.clientChainGateway")));
+        clientGateway = IClientChainGateway(
+            payable(stdJson.readAddress(deployedContracts, string.concat(".", clientChainName, ".clientChainGateway")))
+        );
         require(address(clientGateway) != address(0), "clientGateway address should not be empty");
 
-        beaconOracle = EigenLayerBeaconOracle(stdJson.readAddress(deployedContracts, ".clientChain.beaconOracle"));
+        beaconOracle = EigenLayerBeaconOracle(
+            stdJson.readAddress(deployedContracts, string.concat(".", clientChainName, ".beaconOracle"))
+        );
         require(address(beaconOracle) != address(0), "beacon oracle address should not be empty");
 
         // load beacon chain validator container and proof from json file
@@ -50,10 +53,8 @@ contract DepositScript is BaseScript {
         _loadValidatorProof(validatorInfo);
 
         // transfer some gas fee to depositor, relayer and imuachain gateway
-        clientChain = vm.createSelectFork(clientChainRPCURL);
         _topUpPlayer(clientChain, address(0), deployer, depositor.addr, 0.2 ether);
 
-        imuachain = vm.createSelectFork(imuachainRPCURL);
         _topUpPlayer(imuachain, address(0), imuachainGenesis, address(imuachainGateway), 1 ether);
 
         if (!useImuachainPrecompileMock) {

--- a/script/14_CorrectBootstrapErrors.s.sol
+++ b/script/14_CorrectBootstrapErrors.s.sol
@@ -144,7 +144,7 @@ contract CorrectBootstrapErrors is BaseScript {
             vm.serializeAddress(clientChainContracts, "beaconOracle", address(beaconOracle));
 
         string memory deployedContracts = "deployedContracts";
-        string memory finalJson = vm.serializeString(deployedContracts, "clientChain", clientChainContractsOutput);
+        string memory finalJson = vm.serializeString(deployedContracts, clientChainName, clientChainContractsOutput);
 
         vm.writeJson(finalJson, "script/deployments/correctBootstrapErrors.json");
     }

--- a/script/14_CorrectBootstrapErrors.s.sol
+++ b/script/14_CorrectBootstrapErrors.s.sol
@@ -38,45 +38,55 @@ contract CorrectBootstrapErrors is BaseScript {
         super.setUp();
         // load contracts
         string memory prerequisiteContracts = vm.readFile("script/deployments/prerequisiteContracts.json");
-        clientChainLzEndpoint =
-            ILayerZeroEndpointV2(stdJson.readAddress(prerequisiteContracts, ".clientChain.lzEndpoint"));
+        clientChainLzEndpoint = ILayerZeroEndpointV2(
+            stdJson.readAddress(prerequisiteContracts, string.concat(".", clientChainName, ".lzEndpoint"))
+        );
         require(address(clientChainLzEndpoint) != address(0), "Client chain endpoint not found");
-        restakeToken = ERC20PresetFixedSupply(stdJson.readAddress(prerequisiteContracts, ".clientChain.erc20Token"));
+        restakeToken = ERC20PresetFixedSupply(
+            stdJson.readAddress(prerequisiteContracts, string.concat(".", clientChainName, ".erc20Token"))
+        );
         require(address(restakeToken) != address(0), "Restake token not found");
         clientChain = vm.createSelectFork(clientChainRPCURL);
         // we should use the pre-requisite to save gas instead of deploying our own
-        beaconOracle = EigenLayerBeaconOracle(stdJson.readAddress(prerequisiteContracts, ".clientChain.beaconOracle"));
+        beaconOracle = EigenLayerBeaconOracle(
+            stdJson.readAddress(prerequisiteContracts, string.concat(".", clientChainName, ".beaconOracle"))
+        );
         require(address(beaconOracle) != address(0), "Beacon oracle not found");
         // same for BeaconProxyBytecode
-        beaconProxyBytecode =
-            BeaconProxyBytecode(stdJson.readAddress(prerequisiteContracts, ".clientChain.beaconProxyBytecode"));
+        beaconProxyBytecode = BeaconProxyBytecode(
+            stdJson.readAddress(prerequisiteContracts, string.concat(".", clientChainName, ".beaconProxyBytecode"))
+        );
         require(address(beaconProxyBytecode) != address(0), "Beacon proxy bytecode not found");
         // wstETH on Sepolia
         // https://docs.lido.fi/deployed-contracts/sepolia/
-        wstETH = stdJson.readAddress(prerequisiteContracts, ".clientChain.wstETH");
+        wstETH = stdJson.readAddress(prerequisiteContracts, string.concat(".", clientChainName, ".wstETH"));
         require(wstETH != address(0), "wstETH not found");
 
         string memory deployed = vm.readFile("script/deployments/deployedBootstrapOnly.json");
 
-        proxyAddress = stdJson.readAddress(deployed, ".clientChain.bootstrap");
+        proxyAddress = stdJson.readAddress(deployed, string.concat(".", clientChainName, ".bootstrap"));
         require(address(proxyAddress) != address(0), "bootstrap address should not be empty");
 
-        proxyAdmin = stdJson.readAddress(deployed, ".clientChain.proxyAdmin");
+        proxyAdmin = stdJson.readAddress(deployed, string.concat(".", clientChainName, ".proxyAdmin"));
         require(address(proxyAdmin) != address(0), "proxy admin address should not be empty");
 
-        vaultImplementation = Vault(stdJson.readAddress(deployed, ".clientChain.vaultImplementation"));
+        vaultImplementation =
+            Vault(stdJson.readAddress(deployed, string.concat(".", clientChainName, ".vaultImplementation")));
         require(address(vaultImplementation) != address(0), "vault implementation should not be empty");
 
-        vaultBeacon = UpgradeableBeacon(stdJson.readAddress(deployed, ".clientChain.vaultBeacon"));
+        vaultBeacon =
+            UpgradeableBeacon(stdJson.readAddress(deployed, string.concat(".", clientChainName, ".vaultBeacon")));
         require(address(vaultBeacon) != address(0), "vault beacon should not be empty");
 
-        clientGatewayLogic = stdJson.readAddress(deployed, ".clientChain.clientGatewayLogic");
+        clientGatewayLogic = stdJson.readAddress(deployed, string.concat(".", clientChainName, ".clientGatewayLogic"));
         require(clientGatewayLogic != address(0), "client gateway should not be empty");
 
-        beaconOracle = EigenLayerBeaconOracle(stdJson.readAddress(deployed, ".clientChain.beaconOracle"));
+        beaconOracle =
+            EigenLayerBeaconOracle(stdJson.readAddress(deployed, string.concat(".", clientChainName, ".beaconOracle")));
         require(address(beaconOracle) != address(0), "beacon oracle should not be empty");
 
-        capsuleBeacon = UpgradeableBeacon(stdJson.readAddress(deployed, ".clientChain.capsuleBeacon"));
+        capsuleBeacon =
+            UpgradeableBeacon(stdJson.readAddress(deployed, string.concat(".", clientChainName, ".capsuleBeacon")));
         require(address(capsuleBeacon) != address(0), "imuacapsule beacon should not be empty");
 
         initialization = abi.encodeCall(ClientChainGateway.initialize, (payable(owner.addr)));
@@ -92,7 +102,7 @@ contract CorrectBootstrapErrors is BaseScript {
 
         // Create ImmutableConfig struct
         BootstrapStorage.ImmutableConfig memory config = BootstrapStorage.ImmutableConfig({
-            imuachainChainId: imuachainChainId,
+            imuachainChainId: imuachainEndpointId,
             beaconOracleAddress: address(beaconOracle),
             vaultBeacon: address(vaultBeacon),
             imuaCapsuleBeacon: address(capsuleBeacon),

--- a/script/15_DeploySafeMulstisigWallet.s.sol
+++ b/script/15_DeploySafeMulstisigWallet.s.sol
@@ -15,7 +15,6 @@ contract CreateMultisigScript is BaseScript {
     function setUp() public override {
         super.setUp();
 
-        imuachain = vm.createSelectFork(imuachainRPCURL);
         _topUpPlayer(imuachain, address(0), imuachainGenesis, deployer.addr, 2 ether);
     }
 

--- a/script/16_UpgradeImuaCapsule.s.sol
+++ b/script/16_UpgradeImuaCapsule.s.sol
@@ -14,10 +14,10 @@ contract UpgradeImuaCapsuleScript is BaseScript {
 
         string memory deployedContracts = vm.readFile("script/deployments/deployedContracts.json");
 
-        capsuleBeaconContract =
-            UpgradeableBeacon((stdJson.readAddress(deployedContracts, ".clientChain.capsuleBeacon")));
+        capsuleBeaconContract = UpgradeableBeacon(
+            stdJson.readAddress(deployedContracts, string.concat(".", clientChainName, ".capsuleBeacon"))
+        );
         require(address(capsuleBeaconContract) != address(0), "capsuleBeacon address should not be empty");
-        clientChain = vm.createSelectFork(clientChainRPCURL);
     }
 
     function run() public {

--- a/script/17_WithdrawalValidator.s.sol
+++ b/script/17_WithdrawalValidator.s.sol
@@ -44,11 +44,14 @@ contract WithdrawalValidatorScript is BaseScript {
 
         string memory deployedContracts = vm.readFile("script/deployments/deployedContracts.json");
 
-        clientGateway =
-            IClientChainGateway(payable(stdJson.readAddress(deployedContracts, ".clientChain.clientChainGateway")));
+        clientGateway = IClientChainGateway(
+            payable(stdJson.readAddress(deployedContracts, string.concat(".", clientChainName, ".clientChainGateway")))
+        );
         require(address(clientGateway) != address(0), "clientGateway address should not be empty");
 
-        beaconOracle = EigenLayerBeaconOracle(stdJson.readAddress(deployedContracts, ".clientChain.beaconOracle"));
+        beaconOracle = EigenLayerBeaconOracle(
+            stdJson.readAddress(deployedContracts, string.concat(".", clientChainName, ".beaconOracle"))
+        );
         require(address(beaconOracle) != address(0), "beacon oracle address should not be empty");
 
         // load beacon chain validator container and proof from json file
@@ -63,10 +66,8 @@ contract WithdrawalValidatorScript is BaseScript {
         }
 
         // transfer some gas fee to depositor, relayer and imuachain gateway
-        clientChain = vm.createSelectFork(clientChainRPCURL);
         _topUpPlayer(clientChain, address(0), deployer, depositor.addr, 0.2 ether);
 
-        imuachain = vm.createSelectFork(imuachainRPCURL);
         _topUpPlayer(imuachain, address(0), imuachainGenesis, address(imuachainGateway), 1 ether);
     }
 

--- a/script/19_DeployFaucet.s.sol
+++ b/script/19_DeployFaucet.s.sol
@@ -18,11 +18,8 @@ contract DeployScript is BaseScript {
 
         string memory prerequisites = vm.readFile("script/deployments/prerequisiteContracts.json");
 
-        tokenAddr = stdJson.readAddress(prerequisites, ".clientChain.erc20Token");
+        tokenAddr = stdJson.readAddress(prerequisites, string.concat(".", clientChainName, ".erc20Token"));
         require(tokenAddr != address(0), "token address should not be empty");
-
-        clientChain = vm.createSelectFork(clientChainRPCURL);
-        imuachain = vm.createSelectFork(imuachainRPCURL);
 
         // boolean to decide which item is being deployed on which chain
         // true => client chain, imETH faucet

--- a/script/1_Prerequisites.s.sol
+++ b/script/1_Prerequisites.s.sol
@@ -17,10 +17,7 @@ contract PrerequisitesScript is BaseScript {
     function setUp() public virtual override {
         super.setUp();
 
-        clientChain = vm.createSelectFork(clientChainRPCURL);
-
         // transfer some eth to deployer address
-        imuachain = vm.createSelectFork(imuachainRPCURL);
         _topUpPlayer(imuachain, address(0), imuachainGenesis, deployer.addr, 1 ether);
     }
 
@@ -29,22 +26,22 @@ contract PrerequisitesScript is BaseScript {
         if (useEndpointMock) {
             vm.selectFork(clientChain);
             vm.startBroadcast(deployer.privateKey);
-            clientChainLzEndpoint = new NonShortCircuitEndpointV2Mock(clientChainId, owner.addr);
+            clientChainLzEndpoint = new NonShortCircuitEndpointV2Mock(clientChainEndpointId, owner.addr);
             vm.stopBroadcast();
 
             vm.selectFork(imuachain);
             vm.startBroadcast(deployer.privateKey);
-            imuachainLzEndpoint = new NonShortCircuitEndpointV2Mock(imuachainChainId, owner.addr);
+            imuachainLzEndpoint = new NonShortCircuitEndpointV2Mock(imuachainEndpointId, owner.addr);
             vm.stopBroadcast();
         } else {
-            clientChainLzEndpoint = ILayerZeroEndpointV2(sepoliaEndpointV2);
+            clientChainLzEndpoint = ILayerZeroEndpointV2(clientChainEndpointV2);
             imuachainLzEndpoint = ILayerZeroEndpointV2(imuachainEndpointV2);
         }
 
         if (useImuachainPrecompileMock) {
             vm.selectFork(imuachain);
             vm.startBroadcast(deployer.privateKey);
-            assetsMock = address(new AssetsMock(clientChainId));
+            assetsMock = address(new AssetsMock(clientChainEndpointId));
             delegationMock = address(new DelegationMock());
             rewardMock = address(new RewardMock());
             vm.stopBroadcast();
@@ -70,7 +67,7 @@ contract PrerequisitesScript is BaseScript {
         string memory imuachainContractsOutput =
             vm.serializeAddress(imuachainContracts, "lzEndpoint", address(imuachainLzEndpoint));
 
-        vm.serializeString(deployedContracts, "clientChain", clientChainContractsOutput);
+        vm.serializeString(deployedContracts, clientChainName, clientChainContractsOutput);
         string memory finalJson = vm.serializeString(deployedContracts, "imuachain", imuachainContractsOutput);
 
         vm.writeJson(finalJson, "script/deployments/prerequisiteContracts.json");

--- a/script/4_Deposit.s.sol
+++ b/script/4_Deposit.s.sol
@@ -22,17 +22,22 @@ contract DepositScript is BaseScript {
 
         string memory deployedContracts = vm.readFile("script/deployments/deployedContracts.json");
 
-        clientGateway =
-            IClientChainGateway(payable(stdJson.readAddress(deployedContracts, ".clientChain.clientChainGateway")));
+        clientGateway = IClientChainGateway(
+            payable(stdJson.readAddress(deployedContracts, string.concat(".", clientChainName, ".clientChainGateway")))
+        );
         require(address(clientGateway) != address(0), "clientGateway address should not be empty");
 
-        clientChainLzEndpoint = ILayerZeroEndpointV2(stdJson.readAddress(deployedContracts, ".clientChain.lzEndpoint"));
+        clientChainLzEndpoint = ILayerZeroEndpointV2(
+            stdJson.readAddress(deployedContracts, string.concat(".", clientChainName, ".lzEndpoint"))
+        );
         require(address(clientChainLzEndpoint) != address(0), "clientChainLzEndpoint address should not be empty");
 
-        restakeToken = ERC20PresetFixedSupply(stdJson.readAddress(deployedContracts, ".clientChain.erc20Token"));
+        restakeToken = ERC20PresetFixedSupply(
+            stdJson.readAddress(deployedContracts, string.concat(".", clientChainName, ".erc20Token"))
+        );
         require(address(restakeToken) != address(0), "restakeToken address should not be empty");
 
-        vault = IVault(stdJson.readAddress(deployedContracts, ".clientChain.resVault"));
+        vault = IVault(stdJson.readAddress(deployedContracts, string.concat(".", clientChainName, ".resVault")));
         require(address(vault) != address(0), "vault address should not be empty");
 
         imuachainGateway =
@@ -47,11 +52,9 @@ contract DepositScript is BaseScript {
         }
 
         // transfer some gas fee to depositor, relayer and imuachain gateway
-        clientChain = vm.createSelectFork(clientChainRPCURL);
         _topUpPlayer(clientChain, address(0), deployer, depositor.addr, 0.2 ether);
         _topUpPlayer(clientChain, address(restakeToken), owner, depositor.addr, 2 * DEPOSIT_AMOUNT);
 
-        imuachain = vm.createSelectFork(imuachainRPCURL);
         _topUpPlayer(imuachain, address(0), imuachainGenesis, relayer.addr, 0.2 ether);
         _topUpPlayer(imuachain, address(0), imuachainGenesis, address(imuachainGateway), 2 ether);
     }
@@ -79,15 +82,15 @@ contract DepositScript is BaseScript {
         if (useEndpointMock) {
             vm.selectFork(imuachain);
             vm.startBroadcast(relayer.privateKey);
-            uint64 nonce = imuachainGateway.nextNonce(clientChainId, address(clientGateway).toBytes32());
+            uint64 nonce = imuachainGateway.nextNonce(clientChainEndpointId, address(clientGateway).toBytes32());
             imuachainLzEndpoint.lzReceive{gas: 500_000}(
-                Origin(clientChainId, address(clientGateway).toBytes32(), nonce),
+                Origin(clientChainEndpointId, address(clientGateway).toBytes32(), nonce),
                 address(imuachainGateway),
                 GUID.generate(
                     nonce,
-                    clientChainId,
+                    clientChainEndpointId,
                     address(clientGateway),
-                    imuachainChainId,
+                    imuachainEndpointId,
                     address(imuachainGateway).toBytes32()
                 ),
                 msg_,

--- a/script/6_CreateImuaCapsule.s.sol
+++ b/script/6_CreateImuaCapsule.s.sol
@@ -25,8 +25,9 @@ contract DepositScript is BaseScript {
 
         string memory deployedContracts = vm.readFile("script/deployments/deployedContracts.json");
 
-        clientGateway =
-            IClientChainGateway(payable(stdJson.readAddress(deployedContracts, ".clientChain.clientChainGateway")));
+        clientGateway = IClientChainGateway(
+            payable(stdJson.readAddress(deployedContracts, string.concat(".", clientChainName, ".clientChainGateway")))
+        );
         require(address(clientGateway) != address(0), "clientGateway address should not be empty");
 
         if (!useImuachainPrecompileMock) {
@@ -34,10 +35,7 @@ contract DepositScript is BaseScript {
         }
 
         // transfer some gas fee to depositor, relayer and imuachain gateway
-        clientChain = vm.createSelectFork(clientChainRPCURL);
         _topUpPlayer(clientChain, address(0), deployer, depositor.addr, 0.2 ether);
-
-        imuachain = vm.createSelectFork(imuachainRPCURL);
         _topUpPlayer(imuachain, address(0), imuachainGenesis, address(imuachainGateway), 1 ether);
     }
 

--- a/script/7_DeployBootstrap.s.sol
+++ b/script/7_DeployBootstrap.s.sol
@@ -33,22 +33,27 @@ contract DeployBootstrapOnly is BaseScript {
         super.setUp();
         // load contracts
         string memory prerequisiteContracts = vm.readFile("script/deployments/prerequisiteContracts.json");
-        clientChainLzEndpoint =
-            ILayerZeroEndpointV2(stdJson.readAddress(prerequisiteContracts, ".clientChain.lzEndpoint"));
+        clientChainLzEndpoint = ILayerZeroEndpointV2(
+            stdJson.readAddress(prerequisiteContracts, string.concat(".", clientChainName, ".lzEndpoint"))
+        );
         require(address(clientChainLzEndpoint) != address(0), "Client chain endpoint not found");
-        restakeToken = ERC20PresetFixedSupply(stdJson.readAddress(prerequisiteContracts, ".clientChain.erc20Token"));
+        restakeToken = ERC20PresetFixedSupply(
+            stdJson.readAddress(prerequisiteContracts, string.concat(".", clientChainName, ".erc20Token"))
+        );
         require(address(restakeToken) != address(0), "Restake token not found");
-        clientChain = vm.createSelectFork(clientChainRPCURL);
         // we should use the pre-requisite to save gas instead of deploying our own
-        beaconOracle = EigenLayerBeaconOracle(stdJson.readAddress(prerequisiteContracts, ".clientChain.beaconOracle"));
+        beaconOracle = EigenLayerBeaconOracle(
+            stdJson.readAddress(prerequisiteContracts, string.concat(".", clientChainName, ".beaconOracle"))
+        );
         require(address(beaconOracle) != address(0), "Beacon oracle not found");
         // same for BeaconProxyBytecode
-        beaconProxyBytecode =
-            BeaconProxyBytecode(stdJson.readAddress(prerequisiteContracts, ".clientChain.beaconProxyBytecode"));
+        beaconProxyBytecode = BeaconProxyBytecode(
+            stdJson.readAddress(prerequisiteContracts, string.concat(".", clientChainName, ".beaconProxyBytecode"))
+        );
         require(address(beaconProxyBytecode) != address(0), "Beacon proxy bytecode not found");
         // wstETH on Sepolia
         // https://docs.lido.fi/deployed-contracts/sepolia/
-        wstETH = stdJson.readAddress(prerequisiteContracts, ".clientChain.wstETH");
+        wstETH = stdJson.readAddress(prerequisiteContracts, string.concat(".", clientChainName, ".wstETH"));
         require(wstETH != address(0), "wstETH not found");
         // salt is automatically scoped to the deployer address
         salt = keccak256(abi.encodePacked("Bootstrap"));
@@ -83,7 +88,7 @@ contract DeployBootstrapOnly is BaseScript {
 
         // Create ImmutableConfig struct
         BootstrapStorage.ImmutableConfig memory config = BootstrapStorage.ImmutableConfig({
-            imuachainChainId: imuachainChainId,
+            imuachainChainId: imuachainEndpointId,
             beaconOracleAddress: address(beaconOracle),
             vaultBeacon: address(vaultBeacon),
             imuaCapsuleBeacon: address(capsuleBeacon),
@@ -147,7 +152,7 @@ contract DeployBootstrapOnly is BaseScript {
             vm.serializeAddress(clientChainContracts, "clientGatewayLogic", address(clientGatewayLogic));
 
         string memory deployedContracts = "deployedContracts";
-        string memory finalJson = vm.serializeString(deployedContracts, "clientChain", clientChainContractsOutput);
+        string memory finalJson = vm.serializeString(deployedContracts, clientChainName, clientChainContractsOutput);
 
         vm.writeJson(finalJson, "script/deployments/deployedBootstrapOnly.json");
     }

--- a/script/8_RegisterValidatorsAndDelegate.s.sol
+++ b/script/8_RegisterValidatorsAndDelegate.s.sol
@@ -31,6 +31,7 @@ contract RegisterValidatorsAndDelegate is Script {
         [0 * 1e18, 0 * 1e18, 2500 * 1e18, 500 * 1e18],
         [1000 * 1e18, 0 * 1e18, 0 * 1e18, 2000 * 1e18]
     ];
+    string constant clientChainName = "sepolia";
 
     function setUp() public {
         primaryKey = vm.envUint("TEST_ACCOUNT_THREE_PRIVATE_KEY");
@@ -49,9 +50,9 @@ contract RegisterValidatorsAndDelegate is Script {
         );
 
         string memory deployedContracts = vm.readFile("script/deployments/deployedBootstrapOnly.json");
-        bootstrapAddr = stdJson.readAddress(deployedContracts, ".clientChain.bootstrap");
+        bootstrapAddr = stdJson.readAddress(deployedContracts, string.concat(".", clientChainName, ".bootstrap"));
         require(bootstrapAddr != address(0), "Bootstrap address should not be empty");
-        tokenAddr = stdJson.readAddress(deployedContracts, ".clientChain.erc20Token");
+        tokenAddr = stdJson.readAddress(deployedContracts, string.concat(".", clientChainName, ".erc20Token"));
         require(tokenAddr != address(0), "Token address should not be empty");
     }
 

--- a/script/9_ExtendBootstrapTime.s.sol
+++ b/script/9_ExtendBootstrapTime.s.sol
@@ -14,9 +14,7 @@ contract SetBootstrapTime is BaseScript {
         super.setUp();
         // load contracts
         string memory deployedContracts = vm.readFile("script/deployments/deployedBootstrapOnly.json");
-        bootstrapAddr = stdJson.readAddress(deployedContracts, ".clientChain.bootstrap");
-
-        clientChain = vm.createSelectFork(clientChainRPCURL);
+        bootstrapAddr = stdJson.readAddress(deployedContracts, string.concat(".", clientChainName, ".bootstrap"));
     }
 
     function run() public {

--- a/script/deployments/correctBootstrapErrors.json
+++ b/script/deployments/correctBootstrapErrors.json
@@ -1,5 +1,5 @@
 {
-  "clientChain": {
+  "sepolia": {
     "beaconOracle": "0xd3D285cd1516038dAED61B8BF7Ae2daD63662492",
     "beaconProxyBytecode": "0xA15Ce26ba8E50ac21ecDa1791BAa3bf22a95b575",
     "bootstrap": "0x53f39D2ECd900Fb018180dB692A9fc29c8efD38E",

--- a/script/deployments/deployedBootstrapOnly.json
+++ b/script/deployments/deployedBootstrapOnly.json
@@ -1,5 +1,5 @@
 {
-  "clientChain": {
+  "sepolia": {
     "beaconOracle": "0xd3D285cd1516038dAED61B8BF7Ae2daD63662492",
     "beaconProxyBytecode": "0xA15Ce26ba8E50ac21ecDa1791BAa3bf22a95b575",
     "bootstrap": "0x53f39D2ECd900Fb018180dB692A9fc29c8efD38E",

--- a/script/deployments/deployedContracts.json
+++ b/script/deployments/deployedContracts.json
@@ -1,5 +1,5 @@
 {
-  "clientChain": {
+  "sepolia": {
     "beaconOracle": "0xd3D285cd1516038dAED61B8BF7Ae2daD63662492",
     "beaconProxyBytecode": "0xA15Ce26ba8E50ac21ecDa1791BAa3bf22a95b575",
     "bootstrap": "0x64B5B5A618072C1E4D137f91Af780e3B17A81f3f",

--- a/script/deployments/prerequisiteContracts.json
+++ b/script/deployments/prerequisiteContracts.json
@@ -1,5 +1,5 @@
 {
-  "clientChain": {
+  "sepolia": {
     "beaconOracle": "0xd3D285cd1516038dAED61B8BF7Ae2daD63662492",
     "beaconProxyBytecode": "0xA15Ce26ba8E50ac21ecDa1791BAa3bf22a95b575",
     "erc20Token": "0x83E6850591425e3C1E263c054f4466838B9Bd9e4",

--- a/script/deployments/redeployClientChainGateway.json
+++ b/script/deployments/redeployClientChainGateway.json
@@ -1,5 +1,5 @@
 {
-  "clientChain": {
+  "sepolia": {
     "clientGatewayLogic": "0x7B06d8032021a828F0DaD25808bf4F3177cC67cB"
   }
 }


### PR DESCRIPTION
## Description

closes: #162 

This is targeted at making the chain name in `deployedContracts.json` more explicit to avoid confusing. 

Given some CI jobs like comparing storage layout would depend on this file, we have revised these jobs accordingly. Besides we have optimized foundry scripts to better work with multiple network deployments(sepolia, holesky....)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved flexibility by replacing hardcoded chain names and IDs with dynamic variables and mappings, enabling support for multiple client chains.
  * Updated scripts and configuration to use dynamic JSON keys based on the selected chain name.
  * Standardized usage of endpoint IDs instead of chain IDs throughout deployment and validation scripts.
  * Removed explicit fork creation in several scripts to streamline setup and execution.

* **Chores**
  * Renamed top-level JSON keys in deployment and configuration files from "clientChain" to "sepolia" for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->