### PR TITLE
feat: pectra support in consensus containers

### DIFF
--- a/script/integration/1_DeployBootstrap.s.sol
+++ b/script/integration/1_DeployBootstrap.s.sol
@@ -82,6 +82,7 @@ contract DeployContracts is Script {
     bytes pubkey;
     bytes signature;
     bytes32 depositDataRoot;
+    uint256 pectraTimestamp;
 
     function setUp() private {
         // placate the pre-simulation runner
@@ -129,6 +130,8 @@ contract DeployContracts is Script {
         require(denebTimestamp > 0, "Deneb timestamp must be set");
         beaconGenesisTimestamp = vm.envUint("INTEGRATION_BEACON_GENESIS_TIMESTAMP");
         require(beaconGenesisTimestamp > 0, "Beacon timestamp must be set");
+        pectraTimestamp = vm.envUint("INTEGRATION_PECTRA_TIMESTAMP");
+        require(pectraTimestamp > 0, "Pectra timestamp must be set");
         // can not read uint64 from env
         uint256 secondsPerSlot_ = vm.envUint("INTEGRATION_SECONDS_PER_SLOT");
         require(secondsPerSlot_ > 0, "Seconds per slot must be set");
@@ -181,8 +184,9 @@ contract DeployContracts is Script {
 
     function deployContract() private {
         vm.startBroadcast(contractDeployer);
-        networkConfig =
-            new NetworkConfig(depositAddress, denebTimestamp, slotsPerEpoch, secondsPerSlot, beaconGenesisTimestamp);
+        networkConfig = new NetworkConfig(
+            depositAddress, denebTimestamp, slotsPerEpoch, secondsPerSlot, beaconGenesisTimestamp, pectraTimestamp
+        );
         beaconOracle = new BeaconOracle(address(networkConfig));
 
         /// deploy vault implementation contract, capsule implementation contract

--- a/script/integration/NetworkConfig.sol
+++ b/script/integration/NetworkConfig.sol
@@ -23,6 +23,7 @@ contract NetworkConfig is INetworkConfig {
     /// @param slotsPerEpoch The number of slots per epoch to set for the integration network.
     /// @param secondsPerSlot The number of seconds per slot to set for the integration network.
     /// @param beaconGenesisTimestamp The timestamp of the beacon chain genesis.
+    /// @param pectraTimestamp The timestamp of the pectra hard fork.
     /// @dev Given that this contract is only used during integration testing, the parameters are set in the
     /// constructor and cannot be changed later.
     constructor(
@@ -45,8 +46,10 @@ contract NetworkConfig is INetworkConfig {
         require(secondsPerSlot > 0, "Seconds per slot must be set for integration network");
         require(beaconGenesisTimestamp > 0, "Beacon genesis timestamp must be set for integration network");
         require(pectraTimestamp > 0, "Pectra timestamp must be set for integration network");
-        require(pectraTimestamp >= denebTimestamp, "Pectra timestamp must be after Deneb timestamp");
-        require(denebTimestamp >= beaconGenesisTimestamp, "Deneb timestamp must be after Beacon genesis timestamp");
+        require(pectraTimestamp >= denebTimestamp, "Pectra timestamp must be on or after Deneb timestamp");
+        require(
+            denebTimestamp >= beaconGenesisTimestamp, "Deneb timestamp must be on or after Beacon genesis timestamp"
+        );
         params = NetworkParams(
             deposit, denebTimestamp, slotsPerEpoch, secondsPerSlot, beaconGenesisTimestamp, pectraTimestamp
         );

--- a/script/integration/NetworkConfig.sol
+++ b/script/integration/NetworkConfig.sol
@@ -30,7 +30,8 @@ contract NetworkConfig is INetworkConfig {
         uint256 denebTimestamp,
         uint64 slotsPerEpoch,
         uint64 secondsPerSlot,
-        uint256 beaconGenesisTimestamp
+        uint256 beaconGenesisTimestamp,
+        uint256 pectraTimestamp
     ) {
         // the value of 31337 is known to be a reserved chain id for testing.
         // it is different from Anvil's 1337 to avoid confusion, since it does not support PoS.
@@ -43,7 +44,10 @@ contract NetworkConfig is INetworkConfig {
         require(slotsPerEpoch > 0, "Slots per epoch must be set for integration network");
         require(secondsPerSlot > 0, "Seconds per slot must be set for integration network");
         require(beaconGenesisTimestamp > 0, "Beacon genesis timestamp must be set for integration network");
-        params = NetworkParams(deposit, denebTimestamp, slotsPerEpoch, secondsPerSlot, beaconGenesisTimestamp);
+        require(pectraTimestamp > 0, "Pectra timestamp must be set for integration network");
+        params = NetworkParams(
+            deposit, denebTimestamp, slotsPerEpoch, secondsPerSlot, beaconGenesisTimestamp, pectraTimestamp
+        );
     }
 
     /// @inheritdoc INetworkConfig
@@ -75,6 +79,11 @@ contract NetworkConfig is INetworkConfig {
     /// @inheritdoc INetworkConfig
     function getBeaconGenesisTimestamp() external view returns (uint256) {
         return params.beaconGenesisTimestamp;
+    }
+
+    /// @inheritdoc INetworkConfig
+    function getPectraHardForkTimestamp() external view returns (uint256) {
+        return params.pectraHardForkTimestamp;
     }
 
 }

--- a/script/integration/NetworkConfig.sol
+++ b/script/integration/NetworkConfig.sol
@@ -46,6 +46,8 @@ contract NetworkConfig is INetworkConfig {
         require(secondsPerSlot > 0, "Seconds per slot must be set for integration network");
         require(beaconGenesisTimestamp > 0, "Beacon genesis timestamp must be set for integration network");
         require(pectraTimestamp > 0, "Pectra timestamp must be set for integration network");
+        // sometimes, new networks are launched with either/or/and Deneb + Pectra hard forks.
+        // hence, >= is valid and not just >.
         require(pectraTimestamp >= denebTimestamp, "Pectra timestamp must be on or after Deneb timestamp");
         require(
             denebTimestamp >= beaconGenesisTimestamp, "Deneb timestamp must be on or after Beacon genesis timestamp"

--- a/script/integration/NetworkConfig.sol
+++ b/script/integration/NetworkConfig.sol
@@ -45,6 +45,8 @@ contract NetworkConfig is INetworkConfig {
         require(secondsPerSlot > 0, "Seconds per slot must be set for integration network");
         require(beaconGenesisTimestamp > 0, "Beacon genesis timestamp must be set for integration network");
         require(pectraTimestamp > 0, "Pectra timestamp must be set for integration network");
+        require(pectraTimestamp >= denebTimestamp, "Pectra timestamp must be after Deneb timestamp");
+        require(denebTimestamp >= beaconGenesisTimestamp, "Deneb timestamp must be after Beacon genesis timestamp");
         params = NetworkParams(
             deposit, denebTimestamp, slotsPerEpoch, secondsPerSlot, beaconGenesisTimestamp, pectraTimestamp
         );

--- a/src/core/Bootstrap.sol
+++ b/src/core/Bootstrap.sol
@@ -733,16 +733,22 @@ contract Bootstrap is
         nonReentrant
         nativeRestakingEnabled
     {
-        if (
-            msg.value < AFTER_PECTRA_MIN_ACTIVATION_BALANCE_ETH_PER_VALIDATOR
-                || msg.value > AFTER_PECTRA_MAX_EFFECTIVE_BALANCE_ETH_PER_VALIDATOR
-        ) {
-            revert Errors.NativeRestakingControllerInvalidStakeValue();
-        }
-
         IImuaCapsule capsule = ownerToCapsule[msg.sender];
         if (address(capsule) == address(0)) {
             capsule = IImuaCapsule(createImuaCapsule());
+        }
+
+        if (capsule.isPectraMode()) {
+            if (
+                msg.value < AFTER_PECTRA_MIN_ACTIVATION_BALANCE_ETH_PER_VALIDATOR
+                    || msg.value > AFTER_PECTRA_MAX_EFFECTIVE_BALANCE_ETH_PER_VALIDATOR
+            ) {
+                revert Errors.NativeRestakingControllerInvalidStakeValue();
+            }
+        } else {
+            if (msg.value != AFTER_PECTRA_MIN_ACTIVATION_BALANCE_ETH_PER_VALIDATOR) {
+                revert Errors.NativeRestakingControllerInvalidStakeValue();
+            }
         }
 
         ETH_POS.deposit{value: 32 ether}(pubkey, capsule.capsuleWithdrawalCredentials(), signature, depositDataRoot);

--- a/src/core/ImuaCapsule.sol
+++ b/src/core/ImuaCapsule.sol
@@ -133,7 +133,8 @@ contract ImuaCapsule is ReentrancyGuardUpgradeable, ImuaCapsuleStorage, IImuaCap
             revert WithdrawalCredentialsNotMatch();
         }
 
-        _verifyValidatorContainer(validatorContainer, proof);
+        bool isElectra = proof.beaconBlockTimestamp >= getPectraHardForkTimestamp();
+        _verifyValidatorContainer(validatorContainer, proof, isElectra);
 
         validator.status = VALIDATOR_STATUS.REGISTERED;
         validator.validatorIndex = proof.validatorIndex;
@@ -259,7 +260,8 @@ contract ImuaCapsule is ReentrancyGuardUpgradeable, ImuaCapsuleStorage, IImuaCap
     /// @param proof The proof of the validator container.
     function _verifyValidatorContainer(
         bytes32[] calldata validatorContainer,
-        BeaconChainProofs.ValidatorContainerProof calldata proof
+        BeaconChainProofs.ValidatorContainerProof calldata proof,
+        bool isElectra
     ) internal view {
         bytes32 beaconBlockRoot = getBeaconBlockRoot(proof.beaconBlockTimestamp);
         bytes32 validatorContainerRoot = validatorContainer.merkleizeValidatorContainer();
@@ -268,7 +270,8 @@ contract ImuaCapsule is ReentrancyGuardUpgradeable, ImuaCapsuleStorage, IImuaCap
             proof.validatorIndex,
             beaconBlockRoot,
             proof.stateRoot,
-            proof.stateRootProof
+            proof.stateRootProof,
+            isElectra
         );
         if (!valid) {
             revert InvalidValidatorContainer(validatorContainer.getPubkeyHash());

--- a/src/core/ImuaCapsule.sol
+++ b/src/core/ImuaCapsule.sol
@@ -133,8 +133,7 @@ contract ImuaCapsule is ReentrancyGuardUpgradeable, ImuaCapsuleStorage, IImuaCap
             revert WithdrawalCredentialsNotMatch();
         }
 
-        bool isElectra = proof.beaconBlockTimestamp >= getPectraHardForkTimestamp();
-        _verifyValidatorContainer(validatorContainer, proof, isElectra);
+        _verifyValidatorContainer(validatorContainer, proof);
 
         validator.status = VALIDATOR_STATUS.REGISTERED;
         validator.validatorIndex = proof.validatorIndex;
@@ -260,8 +259,7 @@ contract ImuaCapsule is ReentrancyGuardUpgradeable, ImuaCapsuleStorage, IImuaCap
     /// @param proof The proof of the validator container.
     function _verifyValidatorContainer(
         bytes32[] calldata validatorContainer,
-        BeaconChainProofs.ValidatorContainerProof calldata proof,
-        bool isElectra
+        BeaconChainProofs.ValidatorContainerProof calldata proof
     ) internal view {
         bytes32 beaconBlockRoot = getBeaconBlockRoot(proof.beaconBlockTimestamp);
         bytes32 validatorContainerRoot = validatorContainer.merkleizeValidatorContainer();
@@ -271,7 +269,7 @@ contract ImuaCapsule is ReentrancyGuardUpgradeable, ImuaCapsuleStorage, IImuaCap
             beaconBlockRoot,
             proof.stateRoot,
             proof.stateRootProof,
-            isElectra
+            proof.beaconBlockTimestamp >= getPectraHardForkTimestamp();
         );
         if (!valid) {
             revert InvalidValidatorContainer(validatorContainer.getPubkeyHash());

--- a/src/core/ImuaCapsule.sol
+++ b/src/core/ImuaCapsule.sol
@@ -269,7 +269,7 @@ contract ImuaCapsule is ReentrancyGuardUpgradeable, ImuaCapsuleStorage, IImuaCap
             beaconBlockRoot,
             proof.stateRoot,
             proof.stateRootProof,
-            proof.beaconBlockTimestamp >= getPectraHardForkTimestamp();
+            proof.beaconBlockTimestamp >= getPectraHardForkTimestamp()
         );
         if (!valid) {
             revert InvalidValidatorContainer(validatorContainer.getPubkeyHash());

--- a/src/core/NativeRestakingController.sol
+++ b/src/core/NativeRestakingController.sol
@@ -43,16 +43,22 @@ abstract contract NativeRestakingController is
         nonReentrant
         nativeRestakingEnabled
     {
-        if (
-            msg.value < AFTER_PECTRA_MIN_ACTIVATION_BALANCE_ETH_PER_VALIDATOR
-                || msg.value > AFTER_PECTRA_MAX_EFFECTIVE_BALANCE_ETH_PER_VALIDATOR
-        ) {
-            revert Errors.NativeRestakingControllerInvalidStakeValue();
-        }
-
         IImuaCapsule capsule = ownerToCapsule[msg.sender];
         if (address(capsule) == address(0)) {
             capsule = IImuaCapsule(createImuaCapsule());
+        }
+
+        if (capsule.isPectraMode()) {
+            if (
+                msg.value < AFTER_PECTRA_MIN_ACTIVATION_BALANCE_ETH_PER_VALIDATOR
+                    || msg.value > AFTER_PECTRA_MAX_EFFECTIVE_BALANCE_ETH_PER_VALIDATOR
+            ) {
+                revert Errors.NativeRestakingControllerInvalidStakeValue();
+            }
+        } else {
+            if (msg.value != AFTER_PECTRA_MIN_ACTIVATION_BALANCE_ETH_PER_VALIDATOR) {
+                revert Errors.NativeRestakingControllerInvalidStakeValue();
+            }
         }
 
         ETH_POS.deposit{value: 32 ether}(pubkey, capsule.capsuleWithdrawalCredentials(), signature, depositDataRoot);

--- a/src/interfaces/IImuaCapsule.sol
+++ b/src/interfaces/IImuaCapsule.sol
@@ -55,11 +55,16 @@ interface IImuaCapsule {
 
     /// @notice Returns the withdrawal credentials of the ImuaCapsule.
     /// @return The withdrawal credentials.
-    /// @dev Returns '0x1' + '0x0' * 11 + 'address' of capsule.
+    /// @dev Returns '0x1' + '0x0' * 11 + 'address' of capsule, if non-Pectra.
+    /// @dev Returns '0x2' + '0x0' * 11 + 'address' of capsule, if Pectra.
     function capsuleWithdrawalCredentials() external view returns (bytes memory);
 
     /// @notice Returns if the capsule is in a NST claim progress.
     /// @return True if the capsule is in a NST claim progress, false otherwise.
     function isInClaimProgress() external view returns (bool);
+
+    /// @notice Returns if the capsule is in Pectra mode.
+    /// @return True if the capsule is in Pectra mode, false otherwise.
+    function isPectraMode() external view returns (bool);
 
 }

--- a/src/interfaces/INetworkConfig.sol
+++ b/src/interfaces/INetworkConfig.sol
@@ -31,6 +31,10 @@ interface INetworkConfig {
     /// @return The beacon chain genesis timestamp.
     function getBeaconGenesisTimestamp() external view returns (uint256);
 
+    /// @notice Returns the Pectra hard fork timestamp.
+    /// @return The Pectra hard fork timestamp.
+    function getPectraHardForkTimestamp() external view returns (uint256);
+
 }
 
 /// @notice Struct representing the configuration of a network.
@@ -44,4 +48,5 @@ struct NetworkParams {
     uint64 slotsPerEpoch;
     uint64 secondsPerSlot;
     uint256 beaconGenesisTimestamp;
+    uint256 pectraHardForkTimestamp;
 }

--- a/src/libraries/BeaconChainProofs.sol
+++ b/src/libraries/BeaconChainProofs.sol
@@ -20,6 +20,7 @@ library BeaconChainProofs {
     uint256 internal constant BEACON_BLOCK_BODY_FIELD_TREE_HEIGHT = 4;
 
     uint256 internal constant BEACON_STATE_FIELD_TREE_HEIGHT = 5;
+    uint256 internal constant BEACON_STATE_FIELD_TREE_HEIGHT_ELECTRA = 6;
 
     uint256 internal constant EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT_CAPELLA = 4;
     // After deneb hard fork, it's increased from 4 to 5
@@ -76,11 +77,12 @@ library BeaconChainProofs {
         uint256 validatorIndex,
         bytes32 beaconBlockRoot,
         bytes32 stateRoot,
-        bytes32[] calldata stateRootProof
+        bytes32[] calldata stateRootProof,
+        bool isElectra
     ) internal view returns (bool valid) {
         bool validStateRoot = isValidStateRoot(stateRoot, beaconBlockRoot, stateRootProof);
         bool validVCRootAgainstStateRoot = isValidVCRootAgainstStateRoot(
-            validatorContainerRoot, stateRoot, validatorContainerRootProof, validatorIndex
+            validatorContainerRoot, stateRoot, validatorContainerRootProof, validatorIndex, isElectra
         );
         if (validStateRoot && validVCRootAgainstStateRoot) {
             valid = true;
@@ -106,12 +108,21 @@ library BeaconChainProofs {
         bytes32 validatorContainerRoot,
         bytes32 stateRoot,
         bytes32[] calldata validatorContainerRootProof,
-        uint256 validatorIndex
+        uint256 validatorIndex,
+        bool isElectra
     ) internal view returns (bool) {
-        require(
-            validatorContainerRootProof.length == (VALIDATOR_TREE_HEIGHT + 1) + BEACON_STATE_FIELD_TREE_HEIGHT,
-            "validator container root proof should have 46 nodes"
-        );
+        if (isElectra) {
+            require(
+                validatorContainerRootProof.length
+                    == (VALIDATOR_TREE_HEIGHT + 1) + BEACON_STATE_FIELD_TREE_HEIGHT_ELECTRA,
+                "validator container root proof should have 47 nodes"
+            );
+        } else {
+            require(
+                validatorContainerRootProof.length == (VALIDATOR_TREE_HEIGHT + 1) + BEACON_STATE_FIELD_TREE_HEIGHT,
+                "validator container root proof should have 46 nodes"
+            );
+        }
 
         uint256 leafIndex = (VALIDATOR_TREE_ROOT_INDEX << (VALIDATOR_TREE_HEIGHT + 1)) | uint256(validatorIndex);
 

--- a/src/libraries/NetworkConstants.sol
+++ b/src/libraries/NetworkConstants.sol
@@ -34,7 +34,9 @@ library NetworkConstants {
                 // https://github.com/eth-clients/mainnet/blob/f6b7882618a5ad2c1d2731ae35e5d16a660d5bb7/metadata/config.yaml#L58
                 SECONDS_PER_SLOT_DEFAULT,
                 // https://github.com/eth-clients/mainnet?tab=readme-ov-file
-                1_606_824_023
+                1_606_824_023,
+                // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7600.md
+                1_746_612_311
             );
         } else if (chainId == 11_155_111) {
             // sepolia
@@ -49,7 +51,9 @@ library NetworkConstants {
                 // https://github.com/eth-clients/sepolia/blob/f2c219a93c4491cee3d90c18f2f8e82aed850eab/metadata/config.yaml#L42
                 SECONDS_PER_SLOT_DEFAULT,
                 // https://github.com/eth-clients/sepolia?tab=readme-ov-file#meta-data-bepolia
-                1_655_733_600
+                1_655_733_600,
+                // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7600.md
+                1_741_159_776
             );
         } else if (chainId == 17_000) {
             // holesky
@@ -67,7 +71,28 @@ library NetworkConstants {
                 // for the beacon.
                 // In other words, the genesis time of the execution layer is the same as that of the Beacon.
                 // https://github.com/eth-clients/holesky?tab=readme-ov-file#metadata
-                1_695_902_400
+                1_695_902_400,
+                // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7600.md
+                1_740_434_112
+            );
+        } else if (chainId == 2048) {
+            // hoodi
+            return NetworkParams(
+                // https://github.com/eth-clients/hoodi/blob/3a17a5f5a3e8bccd6609a887f0bbe7ffc71e99e4/metadata/config.yaml#L86
+                0x00000000219ab540356cBB839Cbe05303d7705Fa,
+                // launched with Dencun = Deneb + Cancun
+                // https://github.com/eth-clients/hoodi/tree/main?tab=readme-ov-file#hoodi-hoodi-testnet
+                1_742_212_800,
+                // the `config.yaml` above uses the below preset as a base
+                // https://github.com/ethereum/consensus-specs/blob/a09d0c321550c5411557674a981e2b444a1178c0/presets/mainnet/phase0.yaml#L36
+                SLOTS_PER_EPOCH_DEFAULT,
+                // https://github.com/eth-clients/hoodi/blob/3a17a5f5a3e8bccd6609a887f0bbe7ffc71e99e4/metadata/config.yaml#L46
+                SECONDS_PER_SLOT_DEFAULT,
+                // this is the genesis timestamp of Beacon (== execution in this case)
+                // https://github.com/eth-clients/hoodi/tree/main?tab=readme-ov-file#hoodi-hoodi-testnet
+                1_742_212_800,
+                // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7600.md
+                1_742_999_832
             );
         } else {
             // note that goerli is deprecated
@@ -112,6 +137,12 @@ library NetworkConstants {
     /// @return The beacon chain genesis timestamp.
     function getBeaconGenesisTimestamp() external view returns (uint256) {
         return getNetworkParams().beaconGenesisTimestamp;
+    }
+
+    /// @notice Returns the Pectra hard fork timestamp.
+    /// @return The Pectra hard fork timestamp.
+    function getPectraHardForkTimestamp() external view returns (uint256) {
+        return getNetworkParams().pectraHardForkTimestamp;
     }
 
 }

--- a/src/libraries/NetworkConstants.sol
+++ b/src/libraries/NetworkConstants.sol
@@ -75,7 +75,7 @@ library NetworkConstants {
                 // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7600.md
                 1_740_434_112
             );
-        } else if (chainId == 2048) {
+        } else if (chainId == 560_048) {
             // hoodi
             return NetworkParams(
                 // https://github.com/eth-clients/hoodi/blob/3a17a5f5a3e8bccd6609a887f0bbe7ffc71e99e4/metadata/config.yaml#L86

--- a/src/libraries/NetworkConstants.sol
+++ b/src/libraries/NetworkConstants.sol
@@ -82,7 +82,7 @@ library NetworkConstants {
                 0x00000000219ab540356cBB839Cbe05303d7705Fa,
                 // launched with Dencun = Deneb + Cancun
                 // https://github.com/eth-clients/hoodi/tree/main?tab=readme-ov-file#hoodi-hoodi-testnet
-                1_742_212_800,
+                1_742_213_400,
                 // the `config.yaml` above uses the below preset as a base
                 // https://github.com/ethereum/consensus-specs/blob/a09d0c321550c5411557674a981e2b444a1178c0/presets/mainnet/phase0.yaml#L36
                 SLOTS_PER_EPOCH_DEFAULT,
@@ -90,7 +90,7 @@ library NetworkConstants {
                 SECONDS_PER_SLOT_DEFAULT,
                 // this is the genesis timestamp of Beacon (== execution in this case)
                 // https://github.com/eth-clients/hoodi/tree/main?tab=readme-ov-file#hoodi-hoodi-testnet
-                1_742_212_800,
+                1_742_213_400,
                 // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7600.md
                 1_742_999_832
             );

--- a/src/storage/ImuaCapsuleStorage.sol
+++ b/src/storage/ImuaCapsuleStorage.sol
@@ -107,8 +107,11 @@ contract ImuaCapsuleStorage {
     /// @notice The timestamp of the last successful NST claim.
     uint256 public lastClaimTimestamp;
 
+    /// @notice Whether the creation was done in Pectra mode. Defaults to false.
+    bool public isPectra;
+
     /// @dev Storage gap to allow for future upgrades.
-    uint256[38] private __gap;
+    uint256[37] private __gap;
 
     /// @notice Sets the network configuration contract address for the ImuaCapsule contract.
     /// @param networkConfig_ The address of the NetworkConfig contract.

--- a/src/storage/ImuaCapsuleStorage.sol
+++ b/src/storage/ImuaCapsuleStorage.sol
@@ -152,4 +152,13 @@ contract ImuaCapsuleStorage {
         }
     }
 
+    /// @dev Gets the pectra timestamp, either from the NetworkConfig contract or the NetworkConstants library.
+    function getPectraHardForkTimestamp() internal view returns (uint256) {
+        if (NETWORK_CONFIG == address(0)) {
+            return NetworkConstants.getPectraHardForkTimestamp();
+        } else {
+            return INetworkConfig(NETWORK_CONFIG).getPectraHardForkTimestamp();
+        }
+    }
+
 }

--- a/test/foundry/BootstrapDepositNST.t.sol
+++ b/test/foundry/BootstrapDepositNST.t.sol
@@ -21,6 +21,8 @@ import {Vault} from "src/core/Vault.sol";
 import {CustomProxyAdmin} from "src/utils/CustomProxyAdmin.sol";
 import {MyToken} from "test/foundry/unit/MyToken.sol";
 
+import {NetworkConstants} from "src/libraries/NetworkConstants.sol";
+
 contract BootstrapDepositNSTTest is Test {
 
     using Endian for bytes32;
@@ -70,7 +72,11 @@ contract BootstrapDepositNSTTest is Test {
     event StakedWithCapsule(address indexed staker, address indexed capsule);
 
     function setUp() public {
-        vm.chainId(1); // set chainid to 1 so that capsule implementation can use default network constants
+        // set chainid to 1 so that capsule implementation can use default network constants
+        vm.chainId(1);
+        // non pectra mode
+        uint256 pectraTs = NetworkConstants.getNetworkParams().pectraHardForkTimestamp;
+        vm.warp(pectraTs - 1);
         vm.startPrank(deployer);
 
         whitelistTokens.push(VIRTUAL_STAKED_ETH_ADDRESS);

--- a/test/foundry/unit/Bootstrap.t.sol
+++ b/test/foundry/unit/Bootstrap.t.sol
@@ -23,6 +23,8 @@ import {Origin} from "src/lzApp/OAppReceiverUpgradeable.sol";
 import {BootstrapStorage} from "src/storage/BootstrapStorage.sol";
 import {Action, GatewayStorage} from "src/storage/GatewayStorage.sol";
 
+import {NetworkConstants} from "src/libraries/NetworkConstants.sol";
+
 import "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/GUID.sol";
 import "src/libraries/Errors.sol";
 
@@ -85,7 +87,12 @@ contract BootstrapTest is Test {
         hex"608060405260405161090e38038061090e83398101604081905261002291610460565b61002e82826000610035565b505061058a565b61003e83610100565b6040516001600160a01b038416907f1cf3b03a6cf19fa2baba4df148e9dcabedea7f8a5c07840e207e5c089be95d3e90600090a260008251118061007f5750805b156100fb576100f9836001600160a01b0316635c60da1b6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156100c5573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906100e99190610520565b836102a360201b6100291760201c565b505b505050565b610113816102cf60201b6100551760201c565b6101725760405162461bcd60e51b815260206004820152602560248201527f455243313936373a206e657720626561636f6e206973206e6f74206120636f6e6044820152641d1c9858dd60da1b60648201526084015b60405180910390fd5b6101e6816001600160a01b0316635c60da1b6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156101b3573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906101d79190610520565b6102cf60201b6100551760201c565b61024b5760405162461bcd60e51b815260206004820152603060248201527f455243313936373a20626561636f6e20696d706c656d656e746174696f6e206960448201526f1cc81b9bdd08184818dbdb9d1c9858dd60821b6064820152608401610169565b806102827fa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d5060001b6102de60201b6100641760201c565b80546001600160a01b0319166001600160a01b039290921691909117905550565b60606102c883836040518060600160405280602781526020016108e7602791396102e1565b9392505050565b6001600160a01b03163b151590565b90565b6060600080856001600160a01b0316856040516102fe919061053b565b600060405180830381855af49150503d8060008114610339576040519150601f19603f3d011682016040523d82523d6000602084013e61033e565b606091505b5090925090506103508683838761035a565b9695505050505050565b606083156103c65782516103bf576001600160a01b0385163b6103bf5760405162461bcd60e51b815260206004820152601d60248201527f416464726573733a2063616c6c20746f206e6f6e2d636f6e74726163740000006044820152606401610169565b50816103d0565b6103d083836103d8565b949350505050565b8151156103e85781518083602001fd5b8060405162461bcd60e51b81526004016101699190610557565b80516001600160a01b038116811461041957600080fd5b919050565b634e487b7160e01b600052604160045260246000fd5b60005b8381101561044f578181015183820152602001610437565b838111156100f95750506000910152565b6000806040838503121561047357600080fd5b61047c83610402565b60208401519092506001600160401b038082111561049957600080fd5b818501915085601f8301126104ad57600080fd5b8151818111156104bf576104bf61041e565b604051601f8201601f19908116603f011681019083821181831017156104e7576104e761041e565b8160405282815288602084870101111561050057600080fd5b610511836020830160208801610434565b80955050505050509250929050565b60006020828403121561053257600080fd5b6102c882610402565b6000825161054d818460208701610434565b9190910192915050565b6020815260008251806020840152610576816040850160208701610434565b601f01601f19169190910160400192915050565b61034e806105996000396000f3fe60806040523661001357610011610017565b005b6100115b610027610022610067565b610100565b565b606061004e83836040518060600160405280602781526020016102f260279139610124565b9392505050565b6001600160a01b03163b151590565b90565b600061009a7fa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50546001600160a01b031690565b6001600160a01b0316635c60da1b6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156100d7573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906100fb9190610249565b905090565b3660008037600080366000845af43d6000803e80801561011f573d6000f35b3d6000fd5b6060600080856001600160a01b03168560405161014191906102a2565b600060405180830381855af49150503d806000811461017c576040519150601f19603f3d011682016040523d82523d6000602084013e610181565b606091505b50915091506101928683838761019c565b9695505050505050565b6060831561020d578251610206576001600160a01b0385163b6102065760405162461bcd60e51b815260206004820152601d60248201527f416464726573733a2063616c6c20746f206e6f6e2d636f6e747261637400000060448201526064015b60405180910390fd5b5081610217565b610217838361021f565b949350505050565b81511561022f5781518083602001fd5b8060405162461bcd60e51b81526004016101fd91906102be565b60006020828403121561025b57600080fd5b81516001600160a01b038116811461004e57600080fd5b60005b8381101561028d578181015183820152602001610275565b8381111561029c576000848401525b50505050565b600082516102b4818460208701610272565b9190910192915050565b60208152600082518060208401526102dd816040850160208701610272565b601f01601f1916919091016040019291505056fe416464726573733a206c6f772d6c6576656c2064656c65676174652063616c6c206661696c6564a2646970667358221220d51e81d3bc5ed20a26aeb05dce7e825c503b2061aa78628027300c8d65b9d89a64736f6c634300080c0033416464726573733a206c6f772d6c6576656c2064656c65676174652063616c6c206661696c6564";
 
     function setUp() public {
-        vm.chainId(1); // set chainid to 1 so that capsule implementation can use default network constants
+        // set chainid to 1 so that capsule implementation can use default network constants
+        vm.chainId(1);
+        // non pectra mode
+        uint256 pectraTs = NetworkConstants.getNetworkParams().pectraHardForkTimestamp;
+        vm.warp(pectraTs - 1);
+
         addrs[0] = address(0x1); // Simulated VALIDATOR1 address
         addrs[1] = address(0x2); // Simulated VALIDATOR2 address
         addrs[2] = address(0x3); // Simulated VALIDATOR3 address
@@ -742,27 +749,27 @@ contract BootstrapTest is Test {
     }
 
     function test07_UpdateTvlLimits_NativeEth() public {
-        address[] memory whitelistTokens = new address[](1);
-        whitelistTokens[0] = VIRTUAL_STAKED_ETH_ADDRESS;
-        uint256[] memory tvlLimits = new uint256[](1);
-        tvlLimits[0] = 500;
+        address[] memory whitelistTokens_ = new address[](1);
+        whitelistTokens_[0] = VIRTUAL_STAKED_ETH_ADDRESS;
+        uint256[] memory tvlLimits_ = new uint256[](1);
+        tvlLimits_[0] = 500;
         vm.startPrank(deployer);
         // first add token to whitelist
-        bootstrap.addWhitelistTokens(whitelistTokens, tvlLimits);
+        bootstrap.addWhitelistTokens(whitelistTokens_, tvlLimits_);
         vm.expectRevert(Errors.NoTvlLimitForNativeRestaking.selector);
-        bootstrap.updateTvlLimit(whitelistTokens[0], tvlLimits[0] * 2);
+        bootstrap.updateTvlLimit(whitelistTokens_[0], tvlLimits_[0] * 2);
         vm.stopPrank();
     }
 
-    function test08_ImuachainAddressIsValid() public {
+    function test08_ImuachainAddressIsValid() public view {
         assertTrue(bootstrap.isValidImAddress("im13hasr43vvq8v44xpzh0l6yuym4kca98fhq3xla"));
     }
 
-    function test08_ImuachainAddressIsValid_Length() public {
+    function test08_ImuachainAddressIsValid_Length() public view {
         assertFalse(bootstrap.isValidImAddress("im13hasr43vvq8v44xpzh0l6yuym4kca98fhq3xlaaa"));
     }
 
-    function test08_ImuachainAddressIsValid_Prefix() public {
+    function test08_ImuachainAddressIsValid_Prefix() public view {
         assertFalse(bootstrap.isValidImAddress("mi13hasr43vvq8v44xpzh0l6yuym4kca98fhq3xlaaa"));
     }
 
@@ -829,10 +836,10 @@ contract BootstrapTest is Test {
 
     function test09_DelegateTo_NotEnoughBalance() public {
         test03_RegisterValidator();
-        MyToken myToken = test01_AddWhitelistToken();
+        MyToken myToken_ = test01_AddWhitelistToken();
         vm.startPrank(addrs[0]);
         vm.expectRevert(Errors.BootstrapInsufficientWithdrawableBalance.selector);
-        bootstrap.delegateTo("im13hasr43vvq8v44xpzh0l6yuym4kca98fhq3xla", address(myToken), amounts[0]);
+        bootstrap.delegateTo("im13hasr43vvq8v44xpzh0l6yuym4kca98fhq3xla", address(myToken_), amounts[0]);
     }
 
     function test09_DelegateTo_ZeroAmount() public {
@@ -917,10 +924,10 @@ contract BootstrapTest is Test {
 
     function test10_UndelegateFrom_NotEnoughBalance() public {
         test03_RegisterValidator();
-        MyToken myToken = test01_AddWhitelistToken();
+        MyToken myToken_ = test01_AddWhitelistToken();
         vm.startPrank(addrs[0]);
         vm.expectRevert(Errors.BootstrapInsufficientDelegatedBalance.selector);
-        bootstrap.undelegateFrom("im13hasr43vvq8v44xpzh0l6yuym4kca98fhq3xla", address(myToken), amounts[0], true);
+        bootstrap.undelegateFrom("im13hasr43vvq8v44xpzh0l6yuym4kca98fhq3xla", address(myToken_), amounts[0], true);
     }
 
     function test10_UndelegateFrom_ZeroAmount() public {
@@ -1085,32 +1092,32 @@ contract BootstrapTest is Test {
         vm.stopPrank();
     }
 
-    function test14_IsCommissionValid() public {
+    function test14_IsCommissionValid() public view {
         IValidatorRegistry.Commission memory commission = IValidatorRegistry.Commission(0, 1e18, 1e18);
         assertTrue(bootstrap.isCommissionValid(commission));
     }
 
-    function test14_IsCommissionValidRateLarge() public {
+    function test14_IsCommissionValidRateLarge() public view {
         IValidatorRegistry.Commission memory commission = IValidatorRegistry.Commission(1.1e18, 1e18, 1e18);
         assertFalse(bootstrap.isCommissionValid(commission));
     }
 
-    function test14_IsCommissionValidMaxRateLarge() public {
+    function test14_IsCommissionValidMaxRateLarge() public view {
         IValidatorRegistry.Commission memory commission = IValidatorRegistry.Commission(0, 1.1e18, 1e18);
         assertFalse(bootstrap.isCommissionValid(commission));
     }
 
-    function test14_IsCommissionValidMaxChangeRateLarge() public {
+    function test14_IsCommissionValidMaxChangeRateLarge() public view {
         IValidatorRegistry.Commission memory commission = IValidatorRegistry.Commission(0, 1e18, 1.1e18);
         assertFalse(bootstrap.isCommissionValid(commission));
     }
 
-    function test14_IsCommissionValidRateExceedsMaxRate() public {
+    function test14_IsCommissionValidRateExceedsMaxRate() public view {
         IValidatorRegistry.Commission memory commission = IValidatorRegistry.Commission(0.5e18, 0.2e18, 1e18);
         assertFalse(bootstrap.isCommissionValid(commission));
     }
 
-    function test14_IsCommissionValidMaxChangeRateExceedsMaxRate() public {
+    function test14_IsCommissionValidMaxChangeRateExceedsMaxRate() public view {
         IValidatorRegistry.Commission memory commission = IValidatorRegistry.Commission(0.1e18, 0.2e18, 1e18);
         assertFalse(bootstrap.isCommissionValid(commission));
     }
@@ -1135,13 +1142,13 @@ contract BootstrapTest is Test {
             beaconProxyBytecode: address(beaconProxyBytecode),
             networkConfig: address(0)
         });
-        Bootstrap bootstrapLogic = new Bootstrap(address(clientChainLzEndpoint), config);
+        Bootstrap bootstrapLogic_ = new Bootstrap(address(clientChainLzEndpoint), config);
         vm.expectRevert(Errors.ZeroAddress.selector);
         Bootstrap(
             payable(
                 address(
                     new TransparentUpgradeableProxy(
-                        address(bootstrapLogic),
+                        address(bootstrapLogic_),
                         address(proxyAdmin),
                         abi.encodeCall(
                             bootstrap.initialize,
@@ -1172,14 +1179,13 @@ contract BootstrapTest is Test {
             beaconProxyBytecode: address(beaconProxyBytecode),
             networkConfig: address(0)
         });
-        Bootstrap bootstrapLogic = new Bootstrap(address(clientChainLzEndpoint), config);
-        vm.warp(20);
+        Bootstrap bootstrapLogic_ = new Bootstrap(address(clientChainLzEndpoint), config);
         vm.expectRevert(Errors.BootstrapSpawnTimeAlreadyPast.selector);
         Bootstrap(
             payable(
                 address(
                     new TransparentUpgradeableProxy(
-                        address(bootstrapLogic),
+                        address(bootstrapLogic_),
                         address(proxyAdmin),
                         abi.encodeCall(
                             bootstrap.initialize,
@@ -1210,13 +1216,13 @@ contract BootstrapTest is Test {
             beaconProxyBytecode: address(beaconProxyBytecode),
             networkConfig: address(0)
         });
-        Bootstrap bootstrapLogic = new Bootstrap(address(clientChainLzEndpoint), config);
+        Bootstrap bootstrapLogic_ = new Bootstrap(address(clientChainLzEndpoint), config);
         vm.expectRevert(Errors.ZeroValue.selector);
         Bootstrap(
             payable(
                 address(
                     new TransparentUpgradeableProxy(
-                        address(bootstrapLogic),
+                        address(bootstrapLogic_),
                         address(proxyAdmin),
                         abi.encodeCall(
                             bootstrap.initialize,
@@ -1247,14 +1253,14 @@ contract BootstrapTest is Test {
             beaconProxyBytecode: address(beaconProxyBytecode),
             networkConfig: address(0)
         });
-        Bootstrap bootstrapLogic = new Bootstrap(address(clientChainLzEndpoint), config);
+        Bootstrap bootstrapLogic_ = new Bootstrap(address(clientChainLzEndpoint), config);
         vm.expectRevert(Errors.BootstrapSpawnTimeLessThanDuration.selector);
         vm.warp(20);
         Bootstrap(
             payable(
                 address(
                     new TransparentUpgradeableProxy(
-                        address(bootstrapLogic),
+                        address(bootstrapLogic_),
                         address(proxyAdmin),
                         abi.encodeCall(
                             bootstrap.initialize,
@@ -1285,14 +1291,14 @@ contract BootstrapTest is Test {
             beaconProxyBytecode: address(beaconProxyBytecode),
             networkConfig: address(0)
         });
-        Bootstrap bootstrapLogic = new Bootstrap(address(clientChainLzEndpoint), config);
+        Bootstrap bootstrapLogic_ = new Bootstrap(address(clientChainLzEndpoint), config);
         vm.expectRevert(Errors.BootstrapLockTimeAlreadyPast.selector);
         vm.warp(20);
         Bootstrap(
             payable(
                 address(
                     new TransparentUpgradeableProxy(
-                        address(bootstrapLogic),
+                        address(bootstrapLogic_),
                         address(proxyAdmin),
                         abi.encodeCall(
                             bootstrap.initialize,
@@ -1323,13 +1329,13 @@ contract BootstrapTest is Test {
             beaconProxyBytecode: address(beaconProxyBytecode),
             networkConfig: address(0)
         });
-        Bootstrap bootstrapLogic = new Bootstrap(address(clientChainLzEndpoint), config);
+        Bootstrap bootstrapLogic_ = new Bootstrap(address(clientChainLzEndpoint), config);
         vm.expectRevert(Errors.ZeroAddress.selector);
         Bootstrap(
             payable(
                 address(
                     new TransparentUpgradeableProxy(
-                        address(bootstrapLogic),
+                        address(bootstrapLogic_),
                         address(proxyAdmin),
                         abi.encodeCall(
                             bootstrap.initialize,
@@ -1360,13 +1366,13 @@ contract BootstrapTest is Test {
             beaconProxyBytecode: address(beaconProxyBytecode),
             networkConfig: address(0)
         });
-        Bootstrap bootstrapLogic = new Bootstrap(address(clientChainLzEndpoint), config);
+        Bootstrap bootstrapLogic_ = new Bootstrap(address(clientChainLzEndpoint), config);
         vm.expectRevert(Errors.ZeroAddress.selector);
         Bootstrap(
             payable(
                 address(
                     new TransparentUpgradeableProxy(
-                        address(bootstrapLogic),
+                        address(bootstrapLogic_),
                         address(proxyAdmin),
                         abi.encodeCall(
                             bootstrap.initialize,
@@ -1397,13 +1403,13 @@ contract BootstrapTest is Test {
             beaconProxyBytecode: address(beaconProxyBytecode),
             networkConfig: address(0)
         });
-        Bootstrap bootstrapLogic = new Bootstrap(address(clientChainLzEndpoint), config);
+        Bootstrap bootstrapLogic_ = new Bootstrap(address(clientChainLzEndpoint), config);
         vm.expectRevert(Errors.BootstrapClientChainDataMalformed.selector);
         Bootstrap(
             payable(
                 address(
                     new TransparentUpgradeableProxy(
-                        address(bootstrapLogic),
+                        address(bootstrapLogic_),
                         address(proxyAdmin),
                         abi.encodeCall(
                             bootstrap.initialize,
@@ -1439,17 +1445,15 @@ contract BootstrapTest is Test {
 
     function test16_SetSpawnTime_LessThanOffsetDuration() public {
         vm.startPrank(deployer);
+        vm.warp(offsetDuration - 5);
         vm.expectRevert(Errors.BootstrapSpawnTimeLessThanDuration.selector);
         bootstrap.setSpawnTime(offsetDuration - 1);
     }
 
     function test16_SetSpawnTime_LockTimeNotInFuture() public {
         vm.startPrank(deployer);
-        vm.warp(offsetDuration - 1);
         vm.expectRevert(Errors.BootstrapLockTimeAlreadyPast.selector);
-        // the initial block.timestamp is 1, so subtract 2 here - 1 for
-        // the test and 1 for the warp offset above.
-        bootstrap.setSpawnTime(spawnTime - 2);
+        bootstrap.setSpawnTime(block.timestamp + offsetDuration - 1);
     }
 
     function test17_SetOffsetDuration() public {
@@ -1471,10 +1475,9 @@ contract BootstrapTest is Test {
     }
 
     function test17_SetOffsetDuration_LockTimeNotInFuture() public {
-        vm.warp(offsetDuration - 1);
         vm.startPrank(deployer);
         vm.expectRevert(Errors.BootstrapLockTimeAlreadyPast.selector);
-        bootstrap.setOffsetDuration(offsetDuration + 2);
+        bootstrap.setOffsetDuration(3601);
     }
 
     function test20_WithdrawRewardFromImuachain() public {

--- a/test/foundry/unit/ImuaCapsule.t.sol
+++ b/test/foundry/unit/ImuaCapsule.t.sol
@@ -15,6 +15,8 @@ import "src/libraries/Endian.sol";
 import {Errors} from "src/libraries/Errors.sol";
 import {ImuaCapsuleStorage} from "src/storage/ImuaCapsuleStorage.sol";
 
+import {NetworkConstants} from "src/libraries/NetworkConstants.sol";
+
 contract DepositSetup is Test {
 
     using stdStorage for StdStorage;
@@ -50,7 +52,12 @@ contract DepositSetup is Test {
     uint256 mockCurrentBlockTimestamp;
 
     function setUp() public {
-        vm.chainId(1); // set chainid to 1 so that capsule implementation can use default network constants
+        // set chainid to 1 so that capsule implementation can use default network constants
+        vm.chainId(1);
+        // non pectra mode
+        uint256 pectraTs = NetworkConstants.getNetworkParams().pectraHardForkTimestamp;
+        vm.warp(pectraTs - 1);
+
         string memory validatorInfo = vm.readFile("test/foundry/test-data/validator_container_proof_8955769.json");
 
         validatorContainer = stdJson.readBytes32Array(validatorInfo, ".ValidatorFields");
@@ -359,7 +366,12 @@ contract WithdrawalSetup is Test {
     uint256 depositAmount;
 
     function setUp() public {
-        vm.chainId(1); // set chainid to 1 so that capsule implementation can use default network constants
+        // set chainid to 1 so that capsule implementation can use default network constants
+        vm.chainId(1);
+        // non pectra mode
+        uint256 pectraTs = NetworkConstants.getNetworkParams().pectraHardForkTimestamp;
+        vm.warp(pectraTs - 1);
+
         string memory validatorInfo = vm.readFile("test/foundry/test-data/validator_container_proof_302913.json");
         _setValidatorContainer(validatorInfo);
 

--- a/test/foundry/unit/NetworkConfig.t.sol
+++ b/test/foundry/unit/NetworkConfig.t.sol
@@ -15,6 +15,7 @@ contract NetworkConfigTest is Test {
     uint64 public constant SLOTS_PER_EPOCH = 32;
     uint64 public constant SECONDS_PER_SLOT = 12;
     uint256 public constant BEACON_GENESIS_TIMESTAMP = 1_606_824_023;
+    uint256 public constant PECTRA_TIMESTAMP = 1_746_612_311;
 
     /// @notice Sets up the chain ID for testing and initializes a new contract instance.
     function setUp() public {
@@ -23,7 +24,12 @@ contract NetworkConfigTest is Test {
 
         // Deploy the contract with valid test parameters
         networkConfig = new NetworkConfig(
-            DEPOSIT_CONTRACT_ADDRESS, DENEB_TIMESTAMP, SLOTS_PER_EPOCH, SECONDS_PER_SLOT, BEACON_GENESIS_TIMESTAMP
+            DEPOSIT_CONTRACT_ADDRESS,
+            DENEB_TIMESTAMP,
+            SLOTS_PER_EPOCH,
+            SECONDS_PER_SLOT,
+            BEACON_GENESIS_TIMESTAMP,
+            PECTRA_TIMESTAMP
         );
     }
 
@@ -67,38 +73,61 @@ contract NetworkConfigTest is Test {
         vm.chainId(1);
         vm.expectRevert("only the 31337 chain ID is supported for integration tests");
         new NetworkConfig(
-            DEPOSIT_CONTRACT_ADDRESS, DENEB_TIMESTAMP, SLOTS_PER_EPOCH, SECONDS_PER_SLOT, BEACON_GENESIS_TIMESTAMP
+            DEPOSIT_CONTRACT_ADDRESS,
+            DENEB_TIMESTAMP,
+            SLOTS_PER_EPOCH,
+            SECONDS_PER_SLOT,
+            BEACON_GENESIS_TIMESTAMP,
+            PECTRA_TIMESTAMP
         );
     }
 
     /// @notice Tests if the contract reverts when initialized with an invalid deposit contract address.
     function testRevertInvalidDepositAddress() public {
         vm.expectRevert("Deposit contract address must be set for integration network");
-        new NetworkConfig(address(0), DENEB_TIMESTAMP, SLOTS_PER_EPOCH, SECONDS_PER_SLOT, BEACON_GENESIS_TIMESTAMP);
+        new NetworkConfig(
+            address(0), DENEB_TIMESTAMP, SLOTS_PER_EPOCH, SECONDS_PER_SLOT, BEACON_GENESIS_TIMESTAMP, PECTRA_TIMESTAMP
+        );
     }
 
     /// @notice Tests if the contract reverts when initialized with an invalid Deneb timestamp.
     function testRevertInvalidDenebTimestamp() public {
         vm.expectRevert("Deneb timestamp must be set for integration network");
-        new NetworkConfig(DEPOSIT_CONTRACT_ADDRESS, 0, SLOTS_PER_EPOCH, SECONDS_PER_SLOT, BEACON_GENESIS_TIMESTAMP);
+        new NetworkConfig(
+            DEPOSIT_CONTRACT_ADDRESS, 0, SLOTS_PER_EPOCH, SECONDS_PER_SLOT, BEACON_GENESIS_TIMESTAMP, PECTRA_TIMESTAMP
+        );
     }
 
     /// @notice Tests if the contract reverts when initialized with invalid slots per epoch.
     function testRevertInvalidSlotsPerEpoch() public {
         vm.expectRevert("Slots per epoch must be set for integration network");
-        new NetworkConfig(DEPOSIT_CONTRACT_ADDRESS, DENEB_TIMESTAMP, 0, SECONDS_PER_SLOT, BEACON_GENESIS_TIMESTAMP);
+        new NetworkConfig(
+            DEPOSIT_CONTRACT_ADDRESS, DENEB_TIMESTAMP, 0, SECONDS_PER_SLOT, BEACON_GENESIS_TIMESTAMP, PECTRA_TIMESTAMP
+        );
     }
 
     /// @notice Tests if the contract reverts when initialized with invalid seconds per slot.
     function testRevertInvalidSecondsPerSlot() public {
         vm.expectRevert("Seconds per slot must be set for integration network");
-        new NetworkConfig(DEPOSIT_CONTRACT_ADDRESS, DENEB_TIMESTAMP, SLOTS_PER_EPOCH, 0, BEACON_GENESIS_TIMESTAMP);
+        new NetworkConfig(
+            DEPOSIT_CONTRACT_ADDRESS, DENEB_TIMESTAMP, SLOTS_PER_EPOCH, 0, BEACON_GENESIS_TIMESTAMP, PECTRA_TIMESTAMP
+        );
     }
 
     /// @notice Tests if the contract reverts when initialized with an invalid beacon genesis timestamp.
     function testRevertInvalidBeaconGenesisTimestamp() public {
         vm.expectRevert("Beacon genesis timestamp must be set for integration network");
-        new NetworkConfig(DEPOSIT_CONTRACT_ADDRESS, DENEB_TIMESTAMP, SLOTS_PER_EPOCH, SECONDS_PER_SLOT, 0);
+        new NetworkConfig(
+            DEPOSIT_CONTRACT_ADDRESS, DENEB_TIMESTAMP, SLOTS_PER_EPOCH, SECONDS_PER_SLOT, 0, PECTRA_TIMESTAMP
+        );
+    }
+
+    /// @notice Tests if the contract reverts when initialized with an invalid Pectra timestamp.
+    function testRevertInvalidPectraTimestamp() public {
+        vm.expectRevert("Pectra timestamp must be set for integration network");
+        new NetworkConfig(
+            DEPOSIT_CONTRACT_ADDRESS, DENEB_TIMESTAMP, SLOTS_PER_EPOCH, SECONDS_PER_SLOT, BEACON_GENESIS_TIMESTAMP, 0
+        );
     }
 
 }

--- a/test/foundry/unit/NetworkConfig.t.sol
+++ b/test/foundry/unit/NetworkConfig.t.sol
@@ -34,37 +34,42 @@ contract NetworkConfigTest is Test {
     }
 
     /// @notice Tests if the contract was correctly initialized and returns the correct deposit contract address.
-    function testGetDepositContractAddress() public {
+    function testGetDepositContractAddress() public view {
         assertEq(
             networkConfig.getDepositContractAddress(), DEPOSIT_CONTRACT_ADDRESS, "Deposit contract address mismatch"
         );
     }
 
     /// @notice Tests if the contract correctly returns the Deneb hard fork timestamp.
-    function testGetDenebHardForkTimestamp() public {
+    function testGetDenebHardForkTimestamp() public view {
         assertEq(networkConfig.getDenebHardForkTimestamp(), DENEB_TIMESTAMP, "Deneb timestamp mismatch");
     }
 
     /// @notice Tests if the contract correctly returns the number of slots per epoch.
-    function testGetSlotsPerEpoch() public {
+    function testGetSlotsPerEpoch() public view {
         assertEq(networkConfig.getSlotsPerEpoch(), SLOTS_PER_EPOCH, "Slots per epoch mismatch");
     }
 
     /// @notice Tests if the contract correctly returns the number of seconds per slot.
-    function testGetSecondsPerSlot() public {
+    function testGetSecondsPerSlot() public view {
         assertEq(networkConfig.getSecondsPerSlot(), SECONDS_PER_SLOT, "Seconds per slot mismatch");
     }
 
     /// @notice Tests if the contract correctly calculates the number of seconds per epoch.
-    function testGetSecondsPerEpoch() public {
+    function testGetSecondsPerEpoch() public view {
         assertEq(networkConfig.getSecondsPerEpoch(), SECONDS_PER_SLOT * SLOTS_PER_EPOCH, "Seconds per epoch mismatch");
     }
 
     /// @notice Tests if the contract correctly returns the beacon chain genesis timestamp.
-    function testGetBeaconGenesisTimestamp() public {
+    function testGetBeaconGenesisTimestamp() public view {
         assertEq(
             networkConfig.getBeaconGenesisTimestamp(), BEACON_GENESIS_TIMESTAMP, "Beacon genesis timestamp mismatch"
         );
+    }
+
+    /// @notice Tests if the contract correctly returns the Pectra hard fork timestamp.
+    function testGetPectraHardForkTimestamp() public view {
+        assertEq(networkConfig.getPectraHardForkTimestamp(), PECTRA_TIMESTAMP, "Pectra timestamp mismatch");
     }
 
     /// @notice Tests if the contract reverts when initialized with an unsupported chain ID.


### PR DESCRIPTION
The number of fields in the `BeaconState` container has increased from 28 to 37 as part of the Pectra (Prague + Electra) upgrade. The tree height has therefore increased from 5 to 6.

In this hard fork, other containers are affected; we don't use them.

Also included is support for Hoodi in `NetworkConstants.sol`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Pectra hard fork timestamp across all relevant modules and configuration interfaces.
  * Introduced a new network configuration for the "hoodi" network.
  * Enabled capsule mode detection based on Pectra timestamp, affecting stake validation and withdrawal credentials.

* **Bug Fixes**
  * Improved validation for the Pectra hard fork timestamp to ensure it is set correctly.

* **Tests**
  * Enhanced test coverage to verify handling and validation of the Pectra hard fork timestamp.
  * Updated test environments to simulate pre-Pectra and Pectra modes via blockchain timestamp adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->